### PR TITLE
feat(server): add env var toggle for config loading

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -32,7 +32,7 @@ var rootCmd = &cobra.Command{
 	Short:   "SyftBox CLI",
 	Version: version.Detailed(),
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := loadConfig(cmd)
+		cfg, err := loadConfig(cmd, false)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %s\n", red.Bold(true).Render("ERROR"), err)
 			os.Exit(1)
@@ -130,7 +130,8 @@ func main() {
 
 // loadConfig initializes a config by reading config file/env vars, and cli flags
 // it does not guarantee if the contents are valid, as validation is delegated to the client
-func loadConfig(cmd *cobra.Command) (*config.Config, error) {
+// allows env vars to be ignored which means dev .env can exist while running tests
+func loadConfig(cmd *cobra.Command, ignoreEnv bool) (*config.Config, error) {
 	v := viper.New()
 
 	// config path
@@ -144,9 +145,11 @@ func loadConfig(cmd *cobra.Command) (*config.Config, error) {
 		v.SetConfigType("json")
 	}
 
-	// Set up environment variables
-	v.SetEnvPrefix("SYFTBOX")
-	v.AutomaticEnv()
+	// Only use env vars if not disabled
+	if !ignoreEnv {
+		v.SetEnvPrefix("SYFTBOX")
+		v.AutomaticEnv()
+	}
 
 	// Bind cmd flags to viper & set defaults
 	bindWithDefaults(v, cmd)

--- a/cmd/client/main_test.go
+++ b/cmd/client/main_test.go
@@ -19,7 +19,7 @@ func TestLoadConfigEnv(t *testing.T) {
 	t.Setenv("SYFTBOX_ACCESS_TOKEN", "test-access-token")
 	t.Setenv("SYFTBOX_CONFIG_PATH", "/tmp/syftbox-test.json")
 
-	cfg, err := loadConfig(rootCmd)
+	cfg, err := loadConfig(rootCmd, false)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
@@ -55,7 +55,7 @@ func TestLoadConfigJSON(t *testing.T) {
 	rootCmd.PersistentFlags().Set("config", dummyConfigFile)
 
 	// Call buildConfig
-	cfg, err := loadConfig(rootCmd)
+	cfg, err := loadConfig(rootCmd, true) // ignore env vars
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	require.Equal(t, dummyConfigFile, cfg.Path)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,7 +43,7 @@ var rootCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 
 		// load config
-		cfg, err := loadConfig(cmd)
+		cfg, err := loadConfig(cmd, false)
 		if err != nil {
 			cmd.SilenceUsage = false // show usage
 			return err
@@ -122,7 +122,8 @@ func main() {
 }
 
 // loadConfig initializes viper, reads config file/env vars, and maps values to config
-func loadConfig(cmd *cobra.Command) (*server.Config, error) {
+// allows env vars to be ignored which means dev .env can exist while running tests
+func loadConfig(cmd *cobra.Command, ignoreEnv bool) (*server.Config, error) {
 	v := viper.New()
 
 	// Set up config file
@@ -137,10 +138,12 @@ func loadConfig(cmd *cobra.Command) (*server.Config, error) {
 		v.SetConfigType("json")
 	}
 
-	// Set up environment variables
-	v.SetEnvPrefix("SYFTBOX")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	v.AutomaticEnv()
+	// Only use env vars if not disabled
+	if !ignoreEnv {
+		v.SetEnvPrefix("SYFTBOX")
+		v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+		v.AutomaticEnv()
+	}
 
 	bindWithDefaults(v, cmd)
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -38,7 +38,8 @@ func TestLoadConfigEnv(t *testing.T) {
 	t.Setenv("SYFTBOX_EMAIL_SENDGRID_API_KEY", "sendgrid_api_key")
 
 	// Call loadConfig
-	cfg, err := loadConfig(rootCmd)
+	cfg, err := loadConfig(rootCmd, false)
+
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
@@ -104,7 +105,7 @@ email:
 	rootCmd.Flags().Set("config", dummyConfigFile)
 
 	// Call loadConfig
-	cfg, err := loadConfig(rootCmd)
+	cfg, err := loadConfig(rootCmd, true) // ignore env vars
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
@@ -173,7 +174,7 @@ func TestLoadConfigJSON(t *testing.T) {
 	rootCmd.Flags().Set("config", dummyConfigFile)
 
 	// Call loadConfig
-	cfg, err := loadConfig(rootCmd)
+	cfg, err := loadConfig(rootCmd, true) // ignore env vars
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 


### PR DESCRIPTION
Adds ignoreEnv parameter to loadConfig function to optionally disable environment variable loading, allowing tests to run without interference from development .env files.