### PR TITLE
feat(middlewares): add guest access option to JWTAuth middleware

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -74,7 +74,8 @@ func SetupRoutes(svc *Services, hub *ws.WebsocketHub, httpsEnabled bool) http.Ha
 
 	v1 := r.Group("/api/v1")
 
-	v1.Use(middlewares.JWTAuth(svc.Auth))
+	// enable auth middleware with no guest access
+	v1.Use(middlewares.JWTAuth(svc.Auth, false))
 	// v1.Use(middlewares.RateLimiter("100-S")) // todo
 	{
 		// blob
@@ -96,6 +97,11 @@ func SetupRoutes(svc *Services, hub *ws.WebsocketHub, httpsEnabled bool) http.Ha
 		// websocket events
 		v1.GET("/events", hub.WebsocketHandler)
 
+	}
+
+	// enable auth middleware with guest access
+	v1.Use(middlewares.JWTAuth(svc.Auth, true))
+	{
 		// send rpc routes
 		v1.Any("/send/msg", sendH.SendMsg)
 		v1.GET("/send/poll", sendH.PollForResponse)


### PR DESCRIPTION
This pull request introduces a new feature to the JWT authentication middleware, allowing guest access for specific API routes. The changes include updates to the middleware function and route setup to support this functionality.

### Middleware Enhancements:

* [`internal/server/middlewares/jwtauth.go`](diffhunk://#diff-664a4c1afd7d769745ddd5a08785bde678a98d7006f9684c2fd12ed43b00924aL23-R23): Modified the `JWTAuth` function to accept an additional `allowGuest` parameter. Added logic to permit requests from a guest user (`guest@syft.org`) if `allowGuest` is set to `true`. 
### Route Configuration Updates:

* [`internal/server/routes.go`](diffhunk://#diff-e8c99f22a758df74bd7ee9eb0c578a961d6478403ea8fc27e9ae6b677e2b1640L77-R78): Updated the route setup to apply the `JWTAuth` middleware with `allowGuest` set to `false` for most routes and `true` for specific guest-accessible routes, such as the RPC endpoints. 