### PR TITLE
Add CD flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
 name: Syftbox Deploy
 
-# This workflow deploys Syftbox to different environments and optionally manages versioning.
-# Version management:
-# - Automatically releases version when deploying to production (requires version_type input)
-# - Version types: patch, minor, major (semantic versioning)
+# This workflow deploys Syftbox to development and staging environments.
+# For production releases, use the release.yml workflow instead.
 
 on:
   workflow_dispatch:
@@ -16,34 +14,15 @@ on:
         options:
           - dev
           - stage
-          - prod
-      deploy_type:
-        description: 'What to deploy'
-        required: true
-        default: 'all'
-        type: choice
-        options:
-          - all
-          - client
-          - server
-      version_type:
-        description: 'Version type for production releases (patch/minor/major)'
-        required: false
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
 
 jobs:
-  deploy:
+  build-and-deploy:
+    # Build and deploy to target environment
     runs-on: macos-latest
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Required for svu to work properly with git history
         
       - name: Setup Go
         uses: actions/setup-go@v4
@@ -62,51 +41,6 @@ jobs:
       - name: Setup toolchain
         run: just setup-toolchain
         
-      - name: Install jq
-        run: brew install jq
-        
-      - name: Setup git config
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
-          git config user.name "$(gh api /users/${GITHUB_ACTOR} | jq .name -r)"
-        
-      - name: Show current version
-        run: |
-          echo "Current version information:"
-          just show-version
-        
-      - name: Handle version management (production only)
-        if: inputs.environment == 'prod'
-        run: |
-          # Validate that version_type is provided for production deployments
-          if [ -z "${{ inputs.version_type }}" ]; then
-            echo "Error: version_type is required when deploying to production"
-            exit 1
-          fi
-          
-          echo "Releasing version for production deployment..."
-          just release ${{ inputs.version_type }}
-        
-      - name: Push version changes (production only)
-        if: inputs.environment == 'prod'
-        run: |
-          # Set a new remote URL using HTTPS with the github token
-          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git
-
-          # Push the current branch to the remote repo
-          git push origin
-
-          # Push the tag to the remote repo
-          git push origin --tags
-        
-      - name: Show new version (production only)
-        if: inputs.environment == 'prod'
-        run: |
-          echo "New version information:"
-          just show-version
-        
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh
@@ -121,10 +55,6 @@ jobs:
               echo "${{ secrets.SSH_PRIVATE_KEY_STAGE }}" > ~/.ssh/id_rsa
               ssh-keyscan -H ${{ secrets.SSH_HOST_STAGE }} >> ~/.ssh/known_hosts
               ;;
-            "prod")
-              echo "${{ secrets.SSH_PRIVATE_KEY_PROD }}" > ~/.ssh/id_rsa
-              ssh-keyscan -H ${{ secrets.SSH_HOST_PROD }} >> ~/.ssh/known_hosts
-              ;;
             *)
               echo "Unknown environment: ${{ inputs.environment }}"
               exit 1
@@ -132,7 +62,7 @@ jobs:
           esac
           
           chmod 600 ~/.ssh/id_rsa
-          
+ 
       - name: Deploy to ${{ inputs.environment }}
         run: |
           case "${{ inputs.environment }}" in
@@ -142,28 +72,10 @@ jobs:
             "stage")
               REMOTE="${{ secrets.SSH_USER_STAGE }}@${{ secrets.SSH_HOST_STAGE }}"
               ;;
-            "prod")
-              REMOTE="${{ secrets.SSH_USER_PROD }}@${{ secrets.SSH_HOST_PROD }}"
-              ;;
             *)
               echo "Unknown environment: ${{ inputs.environment }}"
               exit 1
               ;;
           esac
           
-          case "${{ inputs.deploy_type }}" in
-            "all")
-              just deploy remote="$REMOTE"
-              ;;
-            "client")
-              just deploy-client remote="$REMOTE"
-              ;;
-            "server")
-              just deploy-server remote="$REMOTE"
-              ;;
-            *)
-              echo "Unknown deploy type: ${{ inputs.deploy_type }}"
-              exit 1
-              ;;
-          esac
-
+          just deploy remote="$REMOTE"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,9 @@
 name: Syftbox Deploy
 
 # This workflow deploys Syftbox to different environments and optionally manages versioning.
-# Version management options:
-# - none: Deploy without version changes
-# - release: Update version files, commit, and tag automatically
-# Version types: patch, minor, major (semantic versioning)
+# Version management:
+# - Automatically releases version when deploying to production (requires version_type input)
+# - Version types: patch, minor, major (semantic versioning)
 
 on:
   workflow_dispatch:
@@ -17,7 +16,7 @@ on:
         options:
           - dev
           - stage
-        #   - prod
+          - prod
       deploy_type:
         description: 'What to deploy'
         required: true
@@ -27,16 +26,8 @@ on:
           - all
           - client
           - server
-      version_action:
-        description: 'Version management action'
-        required: false
-        default: 'none'
-        type: choice
-        options:
-          - none
-          - release
       version_type:
-        description: 'Version type (required if version_action is release)'
+        description: 'Version type for production releases (patch/minor/major)'
         required: false
         type: choice
         options:
@@ -82,35 +73,30 @@ jobs:
           git config user.name "$(gh api /users/${GITHUB_ACTOR} | jq .name -r)"
         
       - name: Show current version
-        if: inputs.version_action != 'none'
         run: |
           echo "Current version information:"
           just show-version
         
-      - name: Handle version management
-        if: inputs.version_action != 'none'
+      - name: Handle version management (production only)
+        if: inputs.environment == 'prod'
         run: |
-          # Validate that version_type is provided when version_action is release
-          if [ "${{ inputs.version_action }}" = "release" ]; then
-            if [ -z "${{ inputs.version_type }}" ]; then
-              echo "Error: version_type is required when version_action is release"
-              exit 1
-            fi
+          # Validate that version_type is provided for production deployments
+          if [ -z "${{ inputs.version_type }}" ]; then
+            echo "Error: version_type is required when deploying to production"
+            exit 1
           fi
           
-          if [ "${{ inputs.version_action }}" = "release" ]; then
-            echo "Releasing version..."
-            just release ${{ inputs.version_type }}
-          fi
+          echo "Releasing version for production deployment..."
+          just release ${{ inputs.version_type }}
         
-      - name: Push version changes
-        if: inputs.version_action != 'none'
+      - name: Push version changes (production only)
+        if: inputs.environment == 'prod'
         run: |
           git push origin main
           git push origin --tags
         
-      - name: Show new version
-        if: inputs.version_action != 'none'
+      - name: Show new version (production only)
+        if: inputs.environment == 'prod'
         run: |
           echo "New version information:"
           just show-version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,11 @@
 name: Syftbox Deploy
 
+# This workflow deploys Syftbox to different environments and optionally manages versioning.
+# Version management options:
+# - none: Deploy without version changes
+# - release: Update version files, commit, and tag automatically
+# Version types: patch, minor, major (semantic versioning)
+
 on:
   workflow_dispatch:
     inputs:
@@ -21,6 +27,22 @@ on:
           - all
           - client
           - server
+      version_action:
+        description: 'Version management action'
+        required: false
+        default: 'none'
+        type: choice
+        options:
+          - none
+          - release
+      version_type:
+        description: 'Version type (required if version_action is release)'
+        required: false
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 jobs:
   deploy:
@@ -29,6 +51,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for svu to work properly with git history
         
       - name: Setup Go
         uses: actions/setup-go@v4
@@ -46,6 +70,50 @@ jobs:
         
       - name: Setup toolchain
         run: just setup-toolchain
+        
+      - name: Install jq
+        run: brew install jq
+        
+      - name: Setup git config
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "$(gh api /users/${GITHUB_ACTOR} | jq .name -r)"
+        
+      - name: Show current version
+        if: inputs.version_action != 'none'
+        run: |
+          echo "Current version information:"
+          just show-version
+        
+      - name: Handle version management
+        if: inputs.version_action != 'none'
+        run: |
+          # Validate that version_type is provided when version_action is release
+          if [ "${{ inputs.version_action }}" = "release" ]; then
+            if [ -z "${{ inputs.version_type }}" ]; then
+              echo "Error: version_type is required when version_action is release"
+              exit 1
+            fi
+          fi
+          
+          if [ "${{ inputs.version_action }}" = "release" ]; then
+            echo "Releasing version..."
+            just release ${{ inputs.version_type }}
+          fi
+        
+      - name: Push version changes
+        if: inputs.version_action != 'none'
+        run: |
+          git push origin main
+          git push origin --tags
+        
+      - name: Show new version
+        if: inputs.version_action != 'none'
+        run: |
+          echo "New version information:"
+          just show-version
         
       - name: Setup SSH
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,7 +92,13 @@ jobs:
       - name: Push version changes (production only)
         if: inputs.environment == 'prod'
         run: |
-          git push origin main
+          # Set a new remote URL using HTTPS with the github token
+          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git
+
+          # Push the current branch to the remote repo
+          git push origin
+
+          # Push the tag to the remote repo
           git push origin --tags
         
       - name: Show new version (production only)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,109 @@
+name: Syftbox Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - stage
+        #   - prod
+      deploy_type:
+        description: 'What to deploy'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - client
+          - server
+
+jobs:
+  deploy:
+    runs-on: macos-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          
+      - name: Install just
+        uses: taiki-e/install-action@just
+        
+      - name: Install goreleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: --version
+        
+      - name: Setup toolchain
+        run: just setup-toolchain
+        
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          
+          # Use environment-specific SSH private key
+          case "${{ inputs.environment }}" in
+            "dev")
+              echo "${{ secrets.SSH_PRIVATE_KEY_DEV }}" > ~/.ssh/id_rsa
+              ssh-keyscan -H ${{ secrets.SSH_HOST_DEV }} >> ~/.ssh/known_hosts
+              ;;
+            "stage")
+              echo "${{ secrets.SSH_PRIVATE_KEY_STAGE }}" > ~/.ssh/id_rsa
+              ssh-keyscan -H ${{ secrets.SSH_HOST_STAGE }} >> ~/.ssh/known_hosts
+              ;;
+            "prod")
+              echo "${{ secrets.SSH_PRIVATE_KEY_PROD }}" > ~/.ssh/id_rsa
+              ssh-keyscan -H ${{ secrets.SSH_HOST_PROD }} >> ~/.ssh/known_hosts
+              ;;
+            *)
+              echo "Unknown environment: ${{ inputs.environment }}"
+              exit 1
+              ;;
+          esac
+          
+          chmod 600 ~/.ssh/id_rsa
+          
+      - name: Deploy to ${{ inputs.environment }}
+        run: |
+          case "${{ inputs.environment }}" in
+            "dev")
+              REMOTE="${{ secrets.SSH_USER_DEV }}@${{ secrets.SSH_HOST_DEV }}"
+              ;;
+            "stage")
+              REMOTE="${{ secrets.SSH_USER_STAGE }}@${{ secrets.SSH_HOST_STAGE }}"
+              ;;
+            "prod")
+              REMOTE="${{ secrets.SSH_USER_PROD }}@${{ secrets.SSH_HOST_PROD }}"
+              ;;
+            *)
+              echo "Unknown environment: ${{ inputs.environment }}"
+              exit 1
+              ;;
+          esac
+          
+          case "${{ inputs.deploy_type }}" in
+            "all")
+              just deploy remote="$REMOTE"
+              ;;
+            "client")
+              just deploy-client remote="$REMOTE"
+              ;;
+            "server")
+              just deploy-server remote="$REMOTE"
+              ;;
+            *)
+              echo "Unknown deploy type: ${{ inputs.deploy_type }}"
+              exit 1
+              ;;
+          esac
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+name: Syftbox Release
+
+# This workflow creates a new release and deploys to production.
+# For dev/stage deployments, use the deploy.yml workflow instead.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version type for the release'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  version:
+    # Handle version bumping and tagging
+    runs-on: macos-latest
+    outputs:
+      version: ${{ steps.bump-version.outputs.version }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for svu to work properly with git history
+        
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          
+      - name: Install just
+        uses: taiki-e/install-action@just
+        
+      - name: Install svu
+        run: go install github.com/caarlos0/svu@latest
+                
+      - name: Install jq
+        run: brew install jq
+        
+      - name: Setup git config
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "$(gh api /users/${GITHUB_ACTOR} | jq .name -r)"
+        
+      - name: Show current version
+        run: |
+          echo "Current version information:"
+          just show-version
+        
+      - name: Bump version
+        id: bump-version
+        run: |
+          echo "Releasing version for production deployment..."
+          just release ${{ inputs.version_type }}
+          version=$(git describe --tags --abbrev=0)
+          echo "version=${version}" >> $GITHUB_OUTPUT
+        
+      - name: Push version changes
+        run: |
+          # Set a new remote URL using HTTPS with the github token
+          git remote set-url origin https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git
+
+          # Push the current branch to the remote repo
+          git push origin
+
+          # Push the tag to the remote repo
+          git push origin --tags
+        
+      - name: Show new version
+        run: |
+          echo "New version information:"
+          just show-version
+
+  build-and-deploy:
+    needs: version
+    # Build and deploy to production
+    runs-on: macos-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          
+      - name: Install just
+        uses: taiki-e/install-action@just
+        
+      - name: Install goreleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: --version
+        
+      - name: Setup toolchain
+        run: just setup-toolchain
+        
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY_PROD }}" > ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.SSH_HOST_PROD }} >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/id_rsa
+          
+      - name: Deploy to production
+        run: |
+          REMOTE="${{ secrets.SSH_USER_PROD }}@${{ secrets.SSH_HOST_PROD }}"
+          just deploy remote="$REMOTE"
+        
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ needs.version.outputs.version }}
+          name: ${{ needs.version.outputs.version }}
+          draft: true
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          makeLatest: true
+          generateReleaseNotes: true
+          artifacts: |
+            releases/*.tar.gz
+            releases/*.zip

--- a/justfile
+++ b/justfile
@@ -212,6 +212,7 @@ build-all:
 
 [group('deploy')]
 deploy-client remote="syftbox-yash": build-all
+    #!/bin/bash
     echo "Deploying syftbox client to {{ _cyan }}{{ remote }}{{ _nc }}"
     rm -rf releases && mkdir releases
     cp -r .out/syftbox_client_*.{tar.gz,zip} releases/
@@ -221,6 +222,7 @@ deploy-client remote="syftbox-yash": build-all
 
 [group('deploy')]
 deploy-server remote="syftbox-yash": build-server
+    #!/bin/bash
     echo "Deploying syftbox server to {{ _cyan }}{{ remote }}{{ _nc }}"
     scp .out/syftbox_server_linux_amd64_v1/syftbox_server {{ remote }}:/home/azureuser/syftbox_server_new
     ssh {{ remote }} "rm -fv /home/azureuser/syftbox_server && mv -fv /home/azureuser/syftbox_server_new /home/azureuser/syftbox_server"

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-SYFTBOX_VERSION := "0.5.0"
+SYFTBOX_VERSION := `svu current`
 BUILD_COMMIT := `git rev-parse --short HEAD`
 BUILD_DATE := `date -u +%Y-%m-%dT%H:%M:%SZ`
 BUILD_LD_FLAGS := "-s -w" + " -X github.com/openmined/syftbox/internal/version.Version=" + SYFTBOX_VERSION + " -X github.com/openmined/syftbox/internal/version.Revision=" + BUILD_COMMIT + " -X github.com/openmined/syftbox/internal/version.BuildDate=" + BUILD_DATE
@@ -237,7 +237,148 @@ setup-toolchain:
     go install github.com/swaggo/swag/v2/cmd/swag@latest
     go install github.com/bokwoon95/wgo@latest
     go install filippo.io/mkcert@latest
+    go install github.com/caarlos0/svu@latest
 
 [group('utils')]
 clean:
     rm -rf .data .out releases certs cover.out
+
+[group('version')]
+bump type:
+    #!/bin/bash
+    set -eou pipefail
+
+    # Version Management Commands
+    #
+    # This project uses semantic versioning with svu (https://github.com/caarlos0/svu)
+    # for automatic version calculation based on git tags.
+    #
+    # Workflow:
+    # 1. Use `just show-version` to see current version and next versions
+    # 2. Use `just bump type` to update files only (manual commit/tag)
+    # 3. Use `just release type` to update files, commit, and tag automatically
+    # 4. Use `just update-version-files version=X.Y.Z` for custom versions
+    #
+    # Examples:
+    #   just show-version                    # Show current and next versions
+    #   just bump patch                      # Update files to next patch version
+    #   just bump minor                      # Update files to next minor version
+    #   just bump major                      # Update files to next major version
+    #   just release patch                   # Bump, commit, and tag patch version
+    #   just update-version-files version=1.2.3  # Set specific version
+    
+    if [ -z "{{ type }}" ]; then
+        echo -e "{{ _red }}Error: bump type is required{{ _nc }}"
+        echo "Usage: just bump <patch|minor|major>"
+        echo "Examples:"
+        echo "  just bump patch"
+        echo "  just bump minor"
+        echo "  just bump major"
+        exit 1
+    fi
+    
+    # Validate bump type
+    if [[ ! "{{ type }}" =~ ^(patch|minor|major)$ ]]; then
+        echo -e "{{ _red }}Error: Invalid bump type '{{ type }}'{{ _nc }}"
+        echo "Valid types: patch, minor, major"
+        exit 1
+    fi
+    
+    echo -e "{{ _cyan }}Bumping {{ type }} version...{{ _nc }}"
+    new_version=$(svu {{ type }} | sed 's/^v//')
+    echo -e "{{ _green }}New version: $new_version{{ _nc }}"
+    just update-version-files version="$new_version"
+    echo -e "{{ _green }}Version bumped to $new_version{{ _nc }}"
+    echo -e "{{ _yellow }}Don't forget to commit and tag:{{ _nc }}"
+    echo "  git add ."
+    echo "  git commit -m \"chore: bump version to $new_version\""
+    echo "  git tag v$new_version"
+
+release type:
+    #!/bin/bash
+    set -eou pipefail
+    
+    if [ -z "{{ type }}" ]; then
+        echo -e "{{ _red }}Error: release type is required{{ _nc }}"
+        echo "Usage: just release <patch|minor|major>"
+        echo "Examples:"
+        echo "  just release patch"
+        echo "  just release minor"
+        echo "  just release major"
+        exit 1
+    fi
+    
+    # Validate release type
+    if [[ ! "{{ type }}" =~ ^(patch|minor|major)$ ]]; then
+        echo -e "{{ _red }}Error: Invalid release type '{{ type }}'{{ _nc }}"
+        echo "Valid types: patch, minor, major"
+        exit 1
+    fi
+    
+    echo -e "{{ _cyan }}Releasing {{ type }} version...{{ _nc }}"
+    new_version=$(svu {{ type }} | sed 's/^v//')
+    echo -e "{{ _green }}New version: $new_version{{ _nc }}"
+    just update-version-files version="$new_version"
+    just commit-and-tag version="$new_version"
+    echo -e "{{ _green }}✓ Released {{ type }} version $new_version{{ _nc }}"
+
+[group('version')]
+show-version:
+    #!/bin/bash
+    set -eou pipefail
+    echo -e "{{ _cyan }}Current version information:{{ _nc }}"
+    echo "  SVU current: $(svu current | sed 's/^v//')"
+    echo "  SVU next patch: $(svu patch | sed 's/^v//')"
+    echo "  SVU next minor: $(svu minor | sed 's/^v//')"
+    echo "  SVU next major: $(svu major | sed 's/^v//')"
+    echo "  Git tags:"
+    git tag --sort=-version:refname | head -5
+
+[group('version')]
+commit-and-tag version:
+    #!/bin/bash
+    set -eou pipefail
+    
+    if [ -z "{{ version }}" ]; then
+        echo -e "{{ _red }}Error: version parameter is required{{ _nc }}"
+        echo "Usage: just commit-and-tag version=1.2.3"
+        exit 1
+    fi
+    
+    echo -e "{{ _cyan }}Committing and tagging version {{ version }}...{{ _nc }}"
+    
+    # Check if there are changes to commit
+    if git diff --quiet && git diff --cached --quiet; then
+        echo -e "{{ _yellow }}No changes to commit{{ _nc }}"
+    else
+        git add .
+        git commit -m "chore: bump version to {{ version }}"
+        echo -e "{{ _green }}✓ Committed changes{{ _nc }}"
+    fi
+    
+    # Create tag
+    git tag v{{ version }}
+    echo -e "{{ _green }}✓ Tagged v{{ version }}{{ _nc }}"
+    
+    echo -e "{{ _green }}Version {{ version }} has been committed and tagged!{{ _nc }}"
+
+[group('version')]
+update-version-files version:
+    #!/bin/bash
+    set -eou pipefail
+    
+    if [ -z "{{ version }}" ]; then
+        echo -e "{{ _red }}Error: version parameter is required{{ _nc }}"
+        echo "Usage: just update-version-files version=1.2.3"
+        exit 1
+    fi
+    
+    echo -e "{{ _cyan }}Updating version to {{ version }} in all files...{{ _nc }}"
+    
+    # Update goreleaser.yaml
+    sed -i "s/-X github.com\/openmined\/syftbox\/internal\/version.Version=.*/-X github.com\/openmined\/syftbox\/internal\/version.Version={{ version }}/g" .goreleaser.yaml
+    echo -e "{{ _green }}✓ Updated .goreleaser.yaml{{ _nc }}"
+    
+    # Update version.go
+    sed -i "s/Version = \".*\"/Version = \"{{ version }}\"/" internal/version/version.go
+    echo -e "{{ _green }}✓ Updated internal/version/version.go{{ _nc }}"


### PR DESCRIPTION
## Overview

This PR introduces a comprehensive release management system that separates development/staging deployments from production releases, and adds automated semantic versioning using `svu` (Semantic Version Util).

**New Version Management Commands:**
- `just show-version` - Display current and next versions
- `just bump <type>` - Update files to next version (manual commit/tag)
- `just release <type>` - Complete release workflow (bump, commit, tag)
- `just update-version-files version=X.Y.Z` - Set specific version
- `just commit-and-tag version=X.Y.Z` - Commit changes and create tag

**Added Dependencies:**
- `svu` (Semantic Version Util) for automated version calculation
- `jq` for JSON processing in workflows

### **Separation of Concerns**
- **Development/Staging**: Quick deployments via `deploy.yml`
- **Production**: Controlled releases via `release.yml` with proper versioning

### **Automated Version Management**
- Semantic versioning based on git tags
- No more manual version updates across multiple files
- Consistent versioning across all build artifacts

### **Improved Release Process**
- Automated GitHub release creation
- Draft releases for review before publishing
- Generated release notes from commits
- Proper artifact management

## 🔧 Usage Examples

### For Development/Staging:
```bash
# Deploy to dev environment
gh workflow run deploy.yml -f environment=dev

# Deploy to staging environment  
gh workflow run deploy.yml -f environment=stage
```

### For Production Releases:
```bash
# Create a patch release (0.5.0 → 0.5.1)
gh workflow run release.yml -f version_type=patch

# Create a minor release (0.5.0 → 0.6.0)
gh workflow run release.yml -f version_type=minor

# Create a major release (0.5.0 → 1.0.0)
gh workflow run release.yml -f version_type=major
```

### Local Version Management:
```bash
# Show current version info
just show-version

# Bump version (files only)
just bump patch

# Complete release workflow
just release patch
```
## 📋 Migration Notes

- **Existing Deployments**: Dev/staging deployments continue to work as before
- **Version Files**: Version is now dynamically calculated from git tags
- **First Release**: Run `just release patch` to create the first versioned release
- **Backward Compatibility**: All existing build and deploy commands remain functional