### PR TITLE
feat: add subdomains

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -184,6 +184,7 @@ func bindWithDefaults(v *viper.Viper, cmd *cobra.Command) {
 	v.SetDefault("http.addr", DefaultBindAddr)
 	v.SetDefault("http.cert_file", "")
 	v.SetDefault("http.key_file", "")
+	v.SetDefault("http.domain", "")
 	// Blob section (config file/env vars only)
 	v.SetDefault("blob.bucket_name", "")
 	v.SetDefault("blob.region", "")

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - SYFTBOX_BLOB_ACCESS_KEY=ptSLdKiwOi2LYQFZYEZ6
       - SYFTBOX_BLOB_SECRET_KEY=GMDvYrAhWDkB2DyFMn8gU8I8Bg0fT3JGT6iEB7P8
       - SYFTBOX_HTTP_ADDR=0.0.0.0:8080
+      - SYFTBOX_HTTP_DOMAIN=syftbox.local
     networks:
       - syftbox-network
     depends_on:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,13 @@
+# SyftBox Documentation
+
+## Overview
+
+SyftBox is a privacy-preserving compute platform that enables secure data sharing and computation across distributed datasites.
+
+## Documentation
+- [Vanity Domains & Subdomain Routing](./vanity-domains.md)
+  - [Overview](./vanity-domains.md#overview)
+  - [Configuration](./vanity-domains.md#configuration-file)
+  - [Testing Locally](./vanity-domains.md#testing-subdomain-routing)
+  - [Security Features](./vanity-domains.md#security-features)
+  - [Implementation Details](./vanity-domains.md#implementation-details)

--- a/docs/vanity-domains.md
+++ b/docs/vanity-domains.md
@@ -1,0 +1,249 @@
+# Vanity Domains
+
+This document describes the vanity domains feature that was implemented for SyftBox subdomain routing.
+
+## Overview
+
+The vanity domains feature provides default subdomains to users and allows them to configure custom domain names that map to their datasites, with the ability to specify custom paths within their datasite. This provides more security and flexibility that the current /datasites/ subfolder system.
+
+## Key Features
+
+- **{email-hash} Subdomains**: alice@example.com becomes https://ff8d9819fc0e12bf.syftbox.tld/
+- **Custom Domains**: Configure any domain you control to point to your datasite
+- **Custom Paths**: Each domain can point to different subdirectories
+- **Hash Domain Override**: Override your default hash subdomain path
+- **{email-hash} Syntax**: Automatically use your hash without knowing it
+- **Hot Reloading**: Changes to settings.yaml are applied automatically
+- **Security**: Moving users to subdomains / domains means protecting pages from XSS
+- **Index.html Auto-serving**: Directories with index.html files serve them automatically
+
+## How It Works
+
+- **{email-hash} Subdomains** The server automatically maps ff8d9819fc0e12bf.syftbox.tld -> syftbox.tld/datasites/alice@example.com/public
+1. **Configuration**: Users can create a `settings.yaml` file in their datasite root directory
+3. **Hot Reload**: When settings.yaml changes, mappings are automatically updated
+4. **Routing**: When a request comes in with a vanity domain, it's routed to the appropriate datasite and path
+5. **Security**: Different CORS headers are sent on subdomains
+
+## Configuration File
+
+Create a `settings.yaml` file in your datasite root (e.g., `alice@example.com/settings.yaml`):
+
+```yaml
+# Datasite settings
+domains:
+  # Use {email-hash} to automatically use your hash subdomain
+  # This allows you to override where your hash subdomain points
+  "{email-hash}": /blog  # e.g., ff8d9819fc0e12bf.syftbox.local → alice@example.com/blog/
+  
+  # Custom vanity domains
+  test.local: /public              # Points to alice@example.com/public/
+  alice.syftbox.dev: /blog          # Points to alice@example.com/blog/
+  portfolio.alice.dev: /portfolio/2024  # Points to alice@example.com/portfolio/2024/
+```
+
+### Special Syntax
+
+- **`{email-hash}`**: This special keyword is automatically replaced with your email's hash subdomain. This allows you to configure your hash subdomain without knowing the actual hash value.
+
+### Default Behavior
+
+- If no settings.yaml exists, your hash subdomain (e.g., `ff8d9819fc0e12bf.syftbox.local`) automatically points to `/public`
+- If settings.yaml exists but doesn't configure `{email-hash}`, the default mapping to `/public` remains
+
+## Implementation Details
+
+### Request Flow: HTTP Request to File Serving
+
+1. **Request Arrival**: Client requests `https://blog.alice.dev/post.html`
+2. **Subdomain Middleware**: 
+   - Extracts host and checks against subdomain mappings
+   - Finds mapping: `blog.alice.dev` → `alice@example.com` + `/blog` path
+   - Rewrites URL path: `/post.html` → `/datasites/alice@example.com/blog/post.html`
+   - Sets context flags for downstream handlers
+3. **Routing**: Detects subdomain request and routes to Explorer handler
+4. **Explorer Handler**:
+   - Checks ACL permissions for the file
+   - Serves the file with proper content-type
+   - Applies security headers for subdomain isolation
+
+### New Datasite Creation Flow
+
+1. **Client uploads first file**: `alice@example.com/public/index.html`
+2. **Blob service** triggers change notification
+3. **HandleBlobChange**:
+   - Detects new datasite `alice@example.com`
+   - Generates hash: `ff8d9819fc0e12bf`
+   - Creates mapping: `ff8d9819fc0e12bf.syftbox.net` → `/public`
+4. **Immediate availability**: Subdomain works without restart
+
+### Settings.yaml Update Flow
+
+1. **Client uploads** `alice@example.com/settings.yaml`:
+   ```yaml
+   domains:
+     "{email-hash}": /blog
+     portfolio.alice.dev: /portfolio/2024
+   ```
+2. **Blob service** detects the file change
+3. **HandleBlobChange** recognizes it's a settings file
+4. **ReloadVanityDomains**:
+   - Clears existing vanity domains for alice@example.com
+   - Parses new configuration
+   - Validates domain ownership
+   - Updates mappings in memory
+5. **Hot reload complete**: New domains work immediately
+
+### Security Features
+
+- **Domain Ownership Validation**: Users cannot claim:
+  - Other users' hash subdomains
+  - The main domain (e.g., syftbox.local)
+  - System domains (e.g., www.syftbox.local)
+- **Hash Detection**: 16-character hex strings are identified as hash subdomains
+- **Security Headers on Subdomains**:
+  - `X-Frame-Options: SAMEORIGIN` - Prevents clickjacking
+  - `X-Content-Type-Options: nosniff` - Prevents MIME type sniffing
+  - `X-XSS-Protection: 1; mode=block` - XSS protection
+  - `Referrer-Policy: same-origin` - Privacy protection
+  - `Content-Security-Policy` - Restricts resource loading
+  - `Permissions-Policy` - Disables sensitive browser features
+- **CORS Isolation**: Each subdomain has strict same-origin policy
+- **ACL Integration**: All existing ACL rules still apply
+- **Path Isolation**: Subdomains cannot access files outside their datasite
+
+
+# Testing Subdomain Routing
+
+This guide shows how to test the subdomain routing feature locally using Docker.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- sudo access (for modifying `/etc/hosts`)
+
+## Quick Start
+
+1. **Start the server and client:**
+   ```bash
+   just run-docker-server
+   just run-docker-client alice@example.com
+   ```
+
+2. **Add local domain:**
+   ```bash
+   echo "127.0.0.1   syftbox.local" | sudo tee -a /etc/hosts
+   echo "127.0.0.1   www.syftbox.local" | sudo tee -a /etc/hosts
+   echo "127.0.0.1   ff8d9819fc0e12bf.syftbox.local" | sudo tee -a /etc/hosts
+   ```
+
+3. **Access in your browser:**
+  NOTE: You will need port 8080 on all local domain urls.
+   - Main site: http://syftbox.local:8080
+   - Alice's subdomain: http://ff8d9819fc0e12bf.syftbox.local:8080
+
+
+4. **Subdomain Hashes**
+The autogenerated subdomains are just a SHA256 of the email.
+```
+echo -n "user@example.com" | shasum -a 256 | cut -c1-16
+```
+
+You can generate them easily using the just command:
+```
+just email-hash alice@example.com
+Email: alice@example.com
+Hash: ff8d9819fc0e12bf
+
+URL: http://ff8d9819fc0e12bf.syftbox.local:8080/
+```
+
+Or for a live url:
+```
+just email-hash alice@example.com syftbox.net
+Email: alice@example.com
+Hash: ff8d9819fc0e12bf
+
+URL: https://ff8d9819fc0e12bf.syftbox.net/
+```
+
+5. Default Behavior
+The default behavior is to map {email-hash}.server.tld to /public.
+This prevents people from accidentally revealing things they might not want to.
+
+This default behavior can be overriden using the `settings.yaml` file.
+
+
+6. Customizing Subdomains
+
+By placing a `settings.yaml` file in the datasite root like so:
+```
+.
+├── blog
+│   ├── index.html
+│   └── syft.pub.yaml
+├── public
+│   └── syft.pub.yaml
+├── settings.yaml
+└── syft.pub.yaml
+```
+
+You can override the default behavior.
+
+The syntax is external:/datasite/path:
+```
+domains:
+    "{email-hash}": /blog # this is a special sytax that resolves to ff8d9819fc0e12bf.server.tld
+    ff8d9819fc0e12bf.syftbox.local: /blog # the same as above but explicit
+    test.local: /blog # this is a custom domain that is pointing to the syftbox server
+```
+
+The above rules change the root to /blog which will then serve up the index.html.
+It will only work if the permissions allow those files to be read, hence the syft.pub.yaml in that folder.
+
+NOTE:
+- We currently have no way to know the owner of the datasite also owns that external domain, this will probably require some  
+private pairing process at some point to prevent others stealing your domains.
+
+The system should hot-reload when ever this file is changed.
+
+7. CORS Headers
+The CORS headers are different on subdomains, we will need to do some testing to get this right but the goal is to prevent users from sending headers or js from the primary bare .syftbox.tld domain, but allowing them to use {email-hash}.syftbox.tld and allowing the browser to isolate each subdomain.
+
+
+## Performance Notes
+
+- **First Access**: There may be a slight delay (1-3 seconds) on first access to a new subdomain due to:
+  - ACL cache warming for new paths
+  - Initial path resolution and routing setup
+  - Database queries for access control validation
+- **Subsequent Access**: Requests to the same subdomain are typically much faster due to caching
+- **Hot Reloading**: Settings changes are detected and applied within seconds
+
+## Testing with Unit Tests
+
+The vanity domain system includes comprehensive unit tests covering:
+
+1. **Subdomain Mapping** (`subdomain_mapping_test.go`)
+   - Hash generation and mapping
+   - Vanity domain CRUD operations
+   - Thread safety and concurrent access
+
+2. **Security Validation** (`datasite_test.go`)
+   - Domain ownership verification
+   - {email-hash} syntax expansion
+   - Rejection of unauthorized domains
+
+3. **Middleware Routing** (`subdomain_test.go`)
+   - Subdomain detection and path rewriting
+   - Root path handling
+   - Context propagation
+
+4. **Integration Tests** (`subdomain_routing_test.go`)
+   - End-to-end routing scenarios
+   - Index.html auto-serving
+   - Relative link generation
+
+## Future Enhancements
+
+1. **Domain Validation**: Verify domain ownership via DNS TXT records

--- a/internal/aclspec/aclspec.go
+++ b/internal/aclspec/aclspec.go
@@ -16,7 +16,9 @@ const (
 
 // IsACLFile checks if the path is an syft.pub.yaml file
 func IsACLFile(path string) bool {
-	return strings.HasSuffix(path, AclFileName)
+	// Extract the base name from the path
+	base := filepath.Base(path)
+	return base == AclFileName
 }
 
 // AsACLPath converts any path to exact acl file path

--- a/internal/aclspec/aclspec_test.go
+++ b/internal/aclspec/aclspec_test.go
@@ -1,0 +1,181 @@
+package aclspec
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestIsACLFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "exact match",
+			path:     "syft.pub.yaml",
+			expected: true,
+		},
+		{
+			name:     "with directory",
+			path:     "user/syft.pub.yaml",
+			expected: true,
+		},
+		{
+			name:     "not an ACL file",
+			path:     "user/file.txt",
+			expected: false,
+		},
+		{
+			name:     "partial match",
+			path:     "user/mysyft.pub.yaml",
+			expected: false,
+		},
+		{
+			name:     "case sensitive",
+			path:     "user/SYFT.PUB.YAML",
+			expected: false,
+		},
+	}
+
+	// Add Windows-specific test cases
+	if runtime.GOOS == "windows" {
+		tests = append(tests, []struct {
+			name     string
+			path     string
+			expected bool
+		}{
+			{
+				name:     "Windows path with backslashes",
+				path:     `C:\Users\test\syft.pub.yaml`,
+				expected: true,
+			},
+			{
+				name:     "Windows path with forward slashes",
+				path:     "C:/Users/test/syft.pub.yaml",
+				expected: true,
+			},
+			{
+				name:     "Windows UNC path",
+				path:     `\\server\share\syft.pub.yaml`,
+				expected: true,
+			},
+		}...)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsACLFile(tt.path)
+			if result != tt.expected {
+				t.Errorf("IsACLFile(%q) = %v, want %v", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAsACLPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "directory path",
+			path:     "user",
+			expected: filepath.Join("user", AclFileName),
+		},
+		{
+			name:     "already an ACL file",
+			path:     "user/syft.pub.yaml",
+			expected: "user/syft.pub.yaml",
+		},
+		{
+			name:     "nested directory",
+			path:     "user/data",
+			expected: filepath.Join("user", "data", AclFileName),
+		},
+	}
+
+	// Add Windows-specific test cases
+	if runtime.GOOS == "windows" {
+		tests = append(tests, []struct {
+			name     string
+			path     string
+			expected string
+		}{
+			{
+				name:     "Windows directory path",
+				path:     `C:\Users\test`,
+				expected: filepath.Join(`C:\Users\test`, AclFileName),
+			},
+			{
+				name:     "Windows path already ACL file",
+				path:     `C:\Users\test\syft.pub.yaml`,
+				expected: `C:\Users\test\syft.pub.yaml`,
+			},
+		}...)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AsACLPath(tt.path)
+			if result != tt.expected {
+				t.Errorf("AsACLPath(%q) = %q, want %q", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWithoutACLPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "path with ACL file",
+			path:     "user/syft.pub.yaml",
+			expected: "user/",
+		},
+		{
+			name:     "path without ACL file",
+			path:     "user/data",
+			expected: "user/data",
+		},
+		{
+			name:     "just ACL file",
+			path:     "syft.pub.yaml",
+			expected: "",
+		},
+	}
+
+	// Add Windows-specific test cases
+	if runtime.GOOS == "windows" {
+		tests = append(tests, []struct {
+			name     string
+			path     string
+			expected string
+		}{
+			{
+				name:     "Windows path with ACL file",
+				path:     `C:\Users\test\syft.pub.yaml`,
+				expected: `C:\Users\test\`,
+			},
+			{
+				name:     "Windows path without ACL file",
+				path:     `C:\Users\test\data`,
+				expected: `C:\Users\test\data`,
+			},
+		}...)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := WithoutACLPath(tt.path)
+			if result != tt.expected {
+				t.Errorf("WithoutACLPath(%q) = %q, want %q", tt.path, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/server/blob/blob_backend_s3.go
+++ b/internal/server/blob/blob_backend_s3.go
@@ -41,6 +41,7 @@ func NewS3Backend(s3Client *s3.Client, config *S3Config) *S3Backend {
 			AfterPutObject:    nil,
 			AfterDeleteObject: nil,
 			AfterCopyObject:   nil,
+			OnBlobChange:      nil,
 		},
 	}
 }

--- a/internal/server/blob/blob_backend_types.go
+++ b/internal/server/blob/blob_backend_types.go
@@ -10,6 +10,7 @@ type blobBackendHooks struct {
 	AfterPutObject    func(req *PutObjectParams, resp *PutObjectResponse)
 	AfterCopyObject   func(req *CopyObjectParams, resp *CopyObjectResponse)
 	AfterDeleteObject func(req string, resp bool)
+	OnBlobChange      func(key string) // New callback for blob changes
 }
 
 // not enforced yet

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -62,6 +62,7 @@ type HTTPConfig struct {
 	Addr         string `mapstructure:"addr"`
 	CertFilePath string `mapstructure:"cert_file"`
 	KeyFilePath  string `mapstructure:"key_file"`
+	Domain       string `mapstructure:"domain"` // Main domain for subdomain routing (e.g., "syftbox.net")
 }
 
 // LogValue for HTTPConfig
@@ -70,6 +71,7 @@ func (hc HTTPConfig) LogValue() slog.Value {
 		slog.String("address", hc.Addr),
 		slog.String("cert_file", hc.CertFilePath),
 		slog.String("key_file", hc.KeyFilePath),
+		slog.String("domain", hc.Domain),
 	)
 }
 

--- a/internal/server/datasite/datasite.go
+++ b/internal/server/datasite/datasite.go
@@ -5,28 +5,41 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/openmined/syftbox/internal/aclspec"
 	"github.com/openmined/syftbox/internal/server/acl"
 	"github.com/openmined/syftbox/internal/server/blob"
+	"github.com/openmined/syftbox/internal/server/middlewares"
 )
 
 type DatasiteService struct {
-	blob *blob.BlobService
-	acl  *acl.ACLService
+	blob              BlobServiceInterface
+	acl               *acl.ACLService
+	subdomainMapping  *SubdomainMapping
+	domain            string // Main domain for generating hash subdomains
 }
 
-func NewDatasiteService(blobSvc *blob.BlobService, aclSvc *acl.ACLService) *DatasiteService {
+func NewDatasiteService(blobSvc BlobServiceInterface, aclSvc *acl.ACLService, domain string) *DatasiteService {
 	return &DatasiteService{
-		blob: blobSvc,
-		acl:  aclSvc,
+		blob:             blobSvc,
+		acl:              aclSvc,
+		subdomainMapping: NewSubdomainMapping(),
+		domain:           domain,
 	}
 }
 
 func (d *DatasiteService) Start(ctx context.Context) error {
 	slog.Debug("datasite service start")
+	
+	// Load subdomain mappings
+	if err := d.LoadDatasiteSubdomains(); err != nil {
+		slog.Warn("failed to load subdomain mappings", "error", err)
+		// Continue anyway - subdomain feature is optional
+	}
+	
 	// Fetch the ACL files
 	start := time.Now()
 	acls, err := d.ListAclFiles()
@@ -149,4 +162,275 @@ func (d *DatasiteService) fetchAcls(ctx context.Context, aclBlobs []*blob.BlobIn
 	wg.Wait()
 
 	return results, nil
+}
+
+// GetSubdomainMapping returns the subdomain mapping service
+func (d *DatasiteService) GetSubdomainMapping() *SubdomainMapping {
+	return d.subdomainMapping
+}
+
+// LoadDatasiteSubdomains loads all datasite emails into the subdomain mapping
+func (d *DatasiteService) LoadDatasiteSubdomains() error {
+	// Get all datasites by listing directories
+	blobs, err := d.blob.Index().List()
+	if err != nil {
+		return fmt.Errorf("error listing blobs: %w", err)
+	}
+	
+	slog.Debug("LoadDatasiteSubdomains: found blobs", "count", len(blobs))
+
+	// Extract unique datasite names (emails)
+	datasiteMap := make(map[string]bool)
+	for _, blob := range blobs {
+		datasite := ExtractDatasiteName(blob.Key)
+		if datasite != "" {
+			datasiteMap[datasite] = true
+			slog.Debug("LoadDatasiteSubdomains: extracted datasite", "blob_key", blob.Key, "datasite", datasite)
+		}
+	}
+	
+	slog.Debug("LoadDatasiteSubdomains: unique datasites found", "count", len(datasiteMap))
+
+	// Convert map to slice
+	datasites := make([]string, 0, len(datasiteMap))
+	for datasite := range datasiteMap {
+		datasites = append(datasites, datasite)
+	}
+
+	// Load mappings
+	slog.Debug("LoadDatasiteSubdomains: loading mappings", "datasites", datasites)
+	d.subdomainMapping.LoadMappings(datasites)
+	
+	// Also add default hash mappings for each datasite
+	for _, datasite := range datasites {
+		d.addDefaultHashMapping(datasite)
+	}
+	
+	slog.Info("loaded datasite subdomain mappings", "count", len(datasites))
+	
+	// Load vanity domain configurations
+	if err := d.LoadVanityDomains(datasites); err != nil {
+		slog.Warn("failed to load vanity domains", "error", err)
+		// Continue anyway - vanity domains are optional
+	}
+	
+	return nil
+}
+
+// LoadVanityDomains loads vanity domain configurations from settings.yaml files
+func (d *DatasiteService) LoadVanityDomains(datasites []string) error {
+	slog.Debug("loading vanity domain configurations", "datasites", len(datasites))
+	
+	for _, email := range datasites {
+		// First, add the default hash-based mapping
+		d.addDefaultHashMapping(email)
+		
+		settingsPath := email + "/settings.yaml"
+		
+		// Try to read settings.yaml
+		resp, err := d.blob.Backend().GetObject(context.Background(), settingsPath)
+		if err != nil {
+			// File might not exist, which is fine
+			slog.Debug("no settings.yaml found", "path", settingsPath)
+			continue
+		}
+		defer resp.Body.Close()
+		
+		// Parse vanity domains
+		settings, err := ParseSettingsYAML(resp.Body)
+		if err != nil {
+			slog.Error("failed to parse settings.yaml", 
+				"path", settingsPath, 
+				"error", err,
+				"action", "skipping vanity domain configuration")
+			continue
+		}
+		
+		// Log parsed domains for debugging
+		slog.Debug("parsed vanity domains from settings.yaml", 
+			"path", settingsPath, 
+			"domains_count", len(settings.VanityDomains),
+			"domains", settings.VanityDomains)
+		
+		// Add vanity domains to mapping
+		for domain, path := range settings.VanityDomains {
+			// Replace {email-hash} with actual hash
+			if domain == "{email-hash}" {
+				hash := middlewares.EmailToSubdomainHash(email)
+				domain = hash + "." + d.domain
+			}
+			
+			// Security check: validate domain ownership
+			if !d.isAllowedDomain(domain, email) {
+				slog.Warn("user tried to claim unauthorized domain", 
+					"email", email, 
+					"domain", domain,
+					"action", "rejected")
+				continue
+			}
+			
+			d.subdomainMapping.AddVanityDomain(domain, email, path)
+			slog.Info("loaded vanity domain", "domain", domain, "email", email, "path", path)
+		}
+	}
+	
+	return nil
+}
+
+// ReloadVanityDomains reloads vanity domain configurations for a specific email
+func (d *DatasiteService) ReloadVanityDomains(email string) error {
+	slog.Debug("reloading vanity domain configurations", "email", email)
+	
+	// Clear existing vanity domains for this email
+	d.subdomainMapping.ClearVanityDomains(email)
+	
+	// Re-add the default hash mapping
+	d.addDefaultHashMapping(email)
+	
+	settingsPath := email + "/settings.yaml"
+	
+	// Try to read settings.yaml
+	resp, err := d.blob.Backend().GetObject(context.Background(), settingsPath)
+	if err != nil {
+		// File might not exist, which is fine
+		slog.Debug("no settings.yaml found", "path", settingsPath)
+		return nil
+	}
+	defer resp.Body.Close()
+	
+	// Parse vanity domains
+	settings, err := ParseSettingsYAML(resp.Body)
+	if err != nil {
+		slog.Error("failed to parse settings.yaml during reload", 
+			"path", settingsPath, 
+			"error", err,
+			"action", "aborting vanity domain reload")
+		return err
+	}
+	
+	// Log parsed domains for debugging
+	slog.Debug("parsed vanity domains from settings.yaml during reload", 
+		"path", settingsPath, 
+		"domains_count", len(settings.VanityDomains),
+		"domains", settings.VanityDomains)
+	
+	// Add vanity domains to mapping
+	for domain, path := range settings.VanityDomains {
+		// Replace {email-hash} with actual hash
+		if domain == "{email-hash}" {
+			hash := middlewares.EmailToSubdomainHash(email)
+			domain = hash + "." + d.domain
+		}
+		
+		// Security check: validate domain ownership
+		if !d.isAllowedDomain(domain, email) {
+			slog.Warn("user tried to claim unauthorized domain", 
+				"email", email, 
+				"domain", domain,
+				"action", "rejected")
+			continue
+		}
+		
+		d.subdomainMapping.AddVanityDomain(domain, email, path)
+		slog.Info("reloaded vanity domain", "domain", domain, "email", email, "path", path)
+	}
+	
+	return nil
+}
+
+// HandleBlobChange handles blob change notifications and reloads settings if needed
+func (d *DatasiteService) HandleBlobChange(key string) {
+	// Extract the datasite name from the key
+	datasiteName := ExtractDatasiteName(key)
+	if datasiteName == "" {
+		return
+	}
+	
+	// Check if this datasite is already in our mapping
+	if !d.subdomainMapping.HasDatasite(datasiteName) {
+		// New datasite detected! Add it to the subdomain mapping
+		slog.Info("new datasite detected, adding to subdomain mapping", "datasite", datasiteName, "key", key)
+		
+		// Add the default hash mapping for this new datasite
+		d.addDefaultHashMapping(datasiteName)
+		
+		// Also check if there's already a settings.yaml file for vanity domains
+		if err := d.ReloadVanityDomains(datasiteName); err != nil {
+			slog.Debug("no vanity domains found for new datasite", "datasite", datasiteName, "error", err)
+		}
+		
+		slog.Info("added new datasite to subdomain mapping", "datasite", datasiteName)
+	}
+	
+	// Check if this is a settings.yaml file change
+	if strings.HasSuffix(key, "/settings.yaml") {
+		slog.Info("settings.yaml changed, reloading vanity domains", "email", datasiteName, "key", key)
+		
+		// Reload vanity domains for this email
+		if err := d.ReloadVanityDomains(datasiteName); err != nil {
+			slog.Warn("failed to reload vanity domains", "email", datasiteName, "error", err)
+		}
+	}
+}
+
+// addDefaultHashMapping adds the default hash-based subdomain mapping
+func (d *DatasiteService) addDefaultHashMapping(email string) {
+	// Only add default mapping if domain is configured
+	if d.domain == "" {
+		return
+	}
+	
+	// Generate the hash for this email
+	hash := middlewares.EmailToSubdomainHash(email)
+	
+	// Create the default hash-based subdomain (e.g., ff8d9819fc0e12bf.syftbox.local)
+	hashDomain := hash + "." + d.domain
+	
+	// Map it to /public by default
+	d.subdomainMapping.AddVanityDomain(hashDomain, email, "/public")
+	slog.Debug("added default hash mapping", "domain", hashDomain, "email", email, "path", "/public")
+}
+
+// isAllowedDomain checks if a user is allowed to claim a domain
+func (d *DatasiteService) isAllowedDomain(domain string, email string) bool {
+	// Calculate this user's hash
+	userHash := middlewares.EmailToSubdomainHash(email)
+	
+	// Check if it's their hash subdomain
+	if strings.HasPrefix(domain, userHash+".") {
+		// Users can always configure their own hash subdomain
+		return true
+	}
+	
+	// Check if it's the main domain or a subdomain of it
+	if d.domain != "" && (domain == d.domain || strings.HasSuffix(domain, "."+d.domain)) {
+		// Don't allow claiming the main domain or other hash subdomains
+		parts := strings.Split(domain, ".")
+		if len(parts) > 0 {
+			possibleHash := parts[0]
+			// Check if first part looks like a hash (16 hex chars)
+			if len(possibleHash) == 16 && isHexString(possibleHash) {
+				// This looks like someone else's hash subdomain
+				return false
+			}
+		}
+		// Don't allow claiming the base domain
+		if domain == d.domain || domain == "www."+d.domain {
+			return false
+		}
+	}
+	
+	// For now, allow other domains (like test.local)
+	// TODO: Implement domain verification for production
+	return true
+}
+
+// isHexString checks if a string contains only hex characters
+func isHexString(s string) bool {
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/server/datasite/datasite_test.go
+++ b/internal/server/datasite/datasite_test.go
@@ -1,0 +1,333 @@
+package datasite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/openmined/syftbox/internal/server/middlewares"
+)
+
+func TestDomainOwnershipValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		domain         string
+		email          string
+		mainDomain     string
+		expectedResult bool
+		description    string
+	}{
+		{
+			name:           "UserCanConfigureOwnHashSubdomain",
+			domain:         "ff8d9819fc0e12bf.syftbox.local",
+			email:          "alice@example.com",
+			mainDomain:     "syftbox.local",
+			expectedResult: true,
+			description:    "Users should be able to configure their own hash subdomain",
+		},
+		{
+			name:           "UserCannotConfigureOthersHashSubdomain",
+			domain:         "1234567890abcdef.syftbox.local",
+			email:          "alice@example.com",
+			mainDomain:     "syftbox.local",
+			expectedResult: false,
+			description:    "Users should not be able to configure other users' hash subdomains",
+		},
+		{
+			name:           "UserCannotClaimMainDomain",
+			domain:         "syftbox.local",
+			email:          "alice@example.com",
+			mainDomain:     "syftbox.local",
+			expectedResult: false,
+			description:    "Users should not be able to claim the main domain",
+		},
+		{
+			name:           "UserCannotClaimWWWDomain",
+			domain:         "www.syftbox.local",
+			email:          "alice@example.com",
+			mainDomain:     "syftbox.local",
+			expectedResult: false,
+			description:    "Users should not be able to claim www subdomain",
+		},
+		{
+			name:           "UserCanClaimCustomDomain",
+			domain:         "alice.dev",
+			email:          "alice@example.com",
+			mainDomain:     "syftbox.local",
+			expectedResult: true,
+			description:    "Users should be able to claim custom domains",
+		},
+		{
+			name:           "UserCanClaimLocalTestDomain",
+			domain:         "test.local",
+			email:          "alice@example.com",
+			mainDomain:     "syftbox.local",
+			expectedResult: true,
+			description:    "Users should be able to claim local test domains",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a minimal datasite service for testing
+			ds := &DatasiteService{domain: tt.mainDomain}
+			
+			result := ds.isAllowedDomain(tt.domain, tt.email)
+			assert.Equal(t, tt.expectedResult, result, tt.description)
+		})
+	}
+}
+
+func TestHelperFunctions(t *testing.T) {
+	t.Run("IsHexString", func(t *testing.T) {
+		tests := []struct {
+			input    string
+			expected bool
+		}{
+			{"ff8d9819fc0e12bf", true},
+			{"1234567890abcdef", true},
+			{"ABCDEF1234567890", true},
+			{"not-hex-string!!", false},
+			{"gg8d9819fc0e12bf", false}, // 'g' is not hex
+			{"", true}, // Empty string technically contains only hex chars
+		}
+
+		for _, tt := range tests {
+			result := isHexString(tt.input)
+			assert.Equal(t, tt.expected, result, "isHexString(%q)", tt.input)
+		}
+	})
+
+	t.Run("ExtractDatasiteName", func(t *testing.T) {
+		tests := []struct {
+			path     string
+			expected string
+		}{
+			{"alice@example.com/public/index.html", "alice@example.com"},
+			{"alice@example.com/", "alice@example.com"},
+			{"alice@example.com", "alice@example.com"}, // Fixed: single email should return itself
+			{"", ""},
+			{"/", ""},
+		}
+
+		for _, tt := range tests {
+			result := ExtractDatasiteName(tt.path)
+			assert.Equal(t, tt.expected, result, "ExtractDatasiteName(%q)", tt.path)
+		}
+	})
+}
+
+func TestEmailHashExpansion(t *testing.T) {
+	email := "alice@example.com"
+	expectedHash := middlewares.EmailToSubdomainHash(email)
+	domain := "{email-hash}"
+	
+	// Create a minimal datasite service
+	ds := &DatasiteService{domain: "syftbox.local"}
+	
+	// Test the logic that would expand {email-hash}
+	// This is the same logic used in LoadVanityDomains
+	if domain == "{email-hash}" {
+		hash := middlewares.EmailToSubdomainHash(email)
+		domain = hash + "." + ds.domain
+	}
+	
+	expectedDomain := expectedHash + ".syftbox.local"
+	assert.Equal(t, expectedDomain, domain, "{email-hash} should expand to user's hash subdomain")
+}
+
+func TestEmailHashConfigParsing(t *testing.T) {
+	tests := []struct {
+		name           string
+		email          string
+		configDomains  map[string]interface{}
+		expectedDomain string
+		expectedPath   string
+		shouldExist    bool
+		description    string
+	}{
+		{
+			name:  "EmailHashWithBlogPath",
+			email: "alice@example.com",
+			configDomains: map[string]interface{}{
+				"{email-hash}": "/blog",
+			},
+			expectedDomain: "ff8d9819fc0e12bf.syftbox.local", // alice@example.com hash
+			expectedPath:   "/blog",
+			shouldExist:    true,
+			description:    "'{email-hash}': /blog should expand to user's hash subdomain with /blog path",
+		},
+		{
+			name:  "EmailHashWithPublicPath",
+			email: "bob@example.com",
+			configDomains: map[string]interface{}{
+				"{email-hash}": "/public",
+			},
+			expectedDomain: "5ff860bf1190596c.syftbox.local", // bob@example.com hash
+			expectedPath:   "/public",
+			shouldExist:    true,
+			description:    "'{email-hash}': /public should expand to user's hash subdomain with /public path",
+		},
+		{
+			name:  "EmailHashWithRootPath",
+			email: "charlie@example.com",
+			configDomains: map[string]interface{}{
+				"{email-hash}": "/",
+			},
+			expectedDomain: "add7232b65bb559f.syftbox.local", // charlie@example.com hash
+			expectedPath:   "/",
+			shouldExist:    true,
+			description:    "'{email-hash}': / should expand to user's hash subdomain with root path",
+		},
+		{
+			name:  "EmailHashWithNestedPath",
+			email: "dave@example.com",
+			configDomains: map[string]interface{}{
+				"{email-hash}": "/projects/2024",
+			},
+			expectedDomain: "7b34211350ff5679.syftbox.local", // dave@example.com hash
+			expectedPath:   "/projects/2024",
+			shouldExist:    true,
+			description:    "'{email-hash}': /projects/2024 should expand to user's hash subdomain with nested path",
+		},
+		{
+			name:  "MultipleDomainsWithEmailHash",
+			email: "alice@example.com",
+			configDomains: map[string]interface{}{
+				"{email-hash}":  "/blog",
+				"alice.dev":     "/portfolio",
+				"custom.domain": "/custom",
+			},
+			expectedDomain: "ff8d9819fc0e12bf.syftbox.local",
+			expectedPath:   "/blog",
+			shouldExist:    true,
+			description:    "Multiple domains including {email-hash} should all be processed correctly",
+		},
+		{
+			name:  "NoEmailHashInConfig",
+			email: "alice@example.com",
+			configDomains: map[string]interface{}{
+				"alice.dev":     "/portfolio",
+				"custom.domain": "/custom",
+			},
+			expectedDomain: "ff8d9819fc0e12bf.syftbox.local",
+			expectedPath:   "",
+			shouldExist:    false,
+			description:    "When {email-hash} is not in config, user's hash subdomain should not be mapped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create subdomain mapping to simulate the vanity domain loading process
+			subdomainMapping := NewSubdomainMapping()
+			
+			// Simulate the LoadVanityDomains process for the specific user
+			mainDomain := "syftbox.local"
+			
+			// Process the config domains (this simulates what LoadVanityDomains does)
+			for domain, pathInterface := range tt.configDomains {
+				path, ok := pathInterface.(string)
+				if !ok {
+					path = "/public" // default
+				}
+				
+				// Expand {email-hash} if present (this is the key logic we're testing)
+				if domain == "{email-hash}" {
+					hash := middlewares.EmailToSubdomainHash(tt.email)
+					domain = hash + "." + mainDomain
+				}
+				
+				// Add the vanity domain mapping
+				subdomainMapping.AddVanityDomain(domain, tt.email, path)
+			}
+			
+			// Test if the expanded domain exists and has correct configuration
+			vanityConfig := subdomainMapping.GetMapping(tt.expectedDomain)
+			
+			if tt.shouldExist {
+				assert.NotNil(t, vanityConfig, tt.description)
+				if vanityConfig != nil {
+					assert.Equal(t, tt.email, vanityConfig.Email, "Email should match")
+					assert.Equal(t, tt.expectedPath, vanityConfig.Path, "Path should match")
+				}
+			} else {
+				assert.Nil(t, vanityConfig, tt.description)
+			}
+		})
+	}
+}
+
+func TestEmailHashConfigIntegration(t *testing.T) {
+	// Test that simulates a real settings.yaml config parsing scenario
+	email := "alice@example.com"
+	expectedHash := middlewares.EmailToSubdomainHash(email)
+	
+	// Simulate YAML config structure
+	type MockSettings struct {
+		Domains map[string]interface{} `yaml:"domains"`
+	}
+	
+	mockSettings := MockSettings{
+		Domains: map[string]interface{}{
+			"{email-hash}":  "/blog",
+			"alice.dev":     "/portfolio", 
+			"alice.site":    "/",
+		},
+	}
+	
+	// Create subdomain mapping and datasite service
+	subdomainMapping := NewSubdomainMapping()
+	mainDomain := "syftbox.local"
+	
+	// Process domains (simulate LoadVanityDomains logic)
+	for domain, pathInterface := range mockSettings.Domains {
+		path, ok := pathInterface.(string)
+		if !ok {
+			path = "/public"
+		}
+		
+		// This is the key expansion logic for {email-hash}
+		if domain == "{email-hash}" {
+			hash := middlewares.EmailToSubdomainHash(email)
+			domain = hash + "." + mainDomain
+		}
+		
+		subdomainMapping.AddVanityDomain(domain, email, path)
+	}
+	
+	// Verify all domains were created correctly
+	expectedDomains := map[string]string{
+		expectedHash + ".syftbox.local": "/blog",      // Expanded from {email-hash}
+		"alice.dev":                     "/portfolio",
+		"alice.site":                    "/",
+	}
+	
+	for expectedDomain, expectedPath := range expectedDomains {
+		config := subdomainMapping.GetMapping(expectedDomain)
+		assert.NotNil(t, config, "Domain %s should exist", expectedDomain)
+		if config != nil {
+			assert.Equal(t, email, config.Email, "Email should match for domain %s", expectedDomain)
+			assert.Equal(t, expectedPath, config.Path, "Path should match for domain %s", expectedDomain)
+		}
+	}
+	
+	// Verify the hash subdomain specifically
+	hashSubdomain := expectedHash + ".syftbox.local"
+	config := subdomainMapping.GetMapping(hashSubdomain)
+	assert.NotNil(t, config, "Hash subdomain should be created from {email-hash}")
+	assert.Equal(t, "/blog", config.Path, "Hash subdomain should have /blog path")
+	
+	// Verify GetVanityDomainFunc would work correctly
+	getVanityDomainFunc := func(domain string) (string, string, bool) {
+		if config := subdomainMapping.GetMapping(domain); config != nil {
+			return config.Email, config.Path, true
+		}
+		return "", "", false
+	}
+	
+	// Test the function with the expanded hash domain
+	returnedEmail, returnedPath, exists := getVanityDomainFunc(hashSubdomain)
+	assert.True(t, exists, "Hash subdomain should be found by GetVanityDomainFunc")
+	assert.Equal(t, email, returnedEmail, "Returned email should match")
+	assert.Equal(t, "/blog", returnedPath, "Returned path should match")
+}

--- a/internal/server/datasite/interfaces.go
+++ b/internal/server/datasite/interfaces.go
@@ -1,0 +1,15 @@
+package datasite
+
+import (
+	"github.com/openmined/syftbox/internal/server/blob"
+)
+
+// BlobServiceInterface defines the minimal interface we need from BlobService
+type BlobServiceInterface interface {
+	Backend() blob.BlobBackend
+	Index() *blob.BlobIndex
+	SetOnBlobChangeCallback(callback func(key string))
+}
+
+// Ensure BlobService implements our interface
+var _ BlobServiceInterface = (*blob.BlobService)(nil)

--- a/internal/server/datasite/subdomain_mapping.go
+++ b/internal/server/datasite/subdomain_mapping.go
@@ -1,0 +1,198 @@
+package datasite
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/openmined/syftbox/internal/server/middlewares"
+)
+
+var (
+	ErrSubdomainNotFound = errors.New("subdomain not found")
+	ErrEmailNotFound     = errors.New("email not found")
+)
+
+// VanityDomainConfig stores the configuration for a vanity domain
+type VanityDomainConfig struct {
+	Email string
+	Path  string // Custom path within the datasite (e.g., "/blog", "/portfolio/2024")
+}
+
+// SubdomainMapping handles bidirectional mapping between email hashes and emails
+type SubdomainMapping struct {
+	mu               sync.RWMutex
+	hashToEmail      map[string]string
+	emailToHash      map[string]string
+	vanityDomains    map[string]*VanityDomainConfig // maps vanity domains to config
+}
+
+// NewSubdomainMapping creates a new subdomain mapping service
+func NewSubdomainMapping() *SubdomainMapping {
+	return &SubdomainMapping{
+		hashToEmail:   make(map[string]string),
+		emailToHash:   make(map[string]string),
+		vanityDomains: make(map[string]*VanityDomainConfig),
+	}
+}
+
+// AddMapping adds a mapping between an email and its hash
+func (s *SubdomainMapping) AddMapping(email string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if mapping already exists
+	if hash, exists := s.emailToHash[email]; exists {
+		return hash
+	}
+
+	// Generate hash for the email
+	hash := middlewares.EmailToSubdomainHash(email)
+	
+	s.hashToEmail[hash] = email
+	s.emailToHash[email] = hash
+	
+	return hash
+}
+
+// GetEmailByHash returns the email for a given hash
+func (s *SubdomainMapping) GetEmailByHash(hash string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	email, exists := s.hashToEmail[hash]
+	if !exists {
+		return "", ErrSubdomainNotFound
+	}
+	
+	return email, nil
+}
+
+// GetHashByEmail returns the hash for a given email
+func (s *SubdomainMapping) GetHashByEmail(email string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	hash, exists := s.emailToHash[email]
+	if !exists {
+		return "", ErrEmailNotFound
+	}
+	
+	return hash, nil
+}
+
+// RemoveMapping removes a mapping by email
+func (s *SubdomainMapping) RemoveMapping(email string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if hash, exists := s.emailToHash[email]; exists {
+		delete(s.hashToEmail, hash)
+		delete(s.emailToHash, email)
+	}
+}
+
+// LoadMappings loads mappings from a list of emails (e.g., from datasites)
+func (s *SubdomainMapping) LoadMappings(emails []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, email := range emails {
+		hash := middlewares.EmailToSubdomainHash(email)
+		s.hashToEmail[hash] = email
+		s.emailToHash[email] = hash
+	}
+}
+
+// GetAllMappings returns all current mappings
+func (s *SubdomainMapping) GetAllMappings() map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Create a copy to avoid race conditions
+	result := make(map[string]string, len(s.hashToEmail))
+	for hash, email := range s.hashToEmail {
+		result[hash] = email
+	}
+	
+	return result
+}
+
+// AddVanityDomain adds a vanity domain mapping
+func (s *SubdomainMapping) AddVanityDomain(domain string, email string, path string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	
+	s.vanityDomains[domain] = &VanityDomainConfig{
+		Email: email,
+		Path:  path,
+	}
+}
+
+// GetVanityDomain returns the configuration for a vanity domain
+func (s *SubdomainMapping) GetVanityDomain(domain string) (*VanityDomainConfig, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	
+	config, exists := s.vanityDomains[domain]
+	return config, exists
+}
+
+// RemoveVanityDomain removes a vanity domain mapping
+func (s *SubdomainMapping) RemoveVanityDomain(domain string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	
+	delete(s.vanityDomains, domain)
+}
+
+// ClearVanityDomains clears all vanity domain mappings for a specific email
+func (s *SubdomainMapping) ClearVanityDomains(email string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	
+	// Find and remove all vanity domains for this email
+	for domain, config := range s.vanityDomains {
+		if config.Email == email {
+			delete(s.vanityDomains, domain)
+		}
+	}
+}
+
+// GetAllVanityDomains returns all vanity domain mappings
+func (s *SubdomainMapping) GetAllVanityDomains() map[string]*VanityDomainConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	
+	// Create a copy to avoid race conditions
+	result := make(map[string]*VanityDomainConfig, len(s.vanityDomains))
+	for domain, config := range s.vanityDomains {
+		result[domain] = &VanityDomainConfig{
+			Email: config.Email,
+			Path:  config.Path,
+		}
+	}
+	
+	return result
+}
+
+// GetMapping returns the mapping for a domain (unified method for both hash and vanity domains)
+func (s *SubdomainMapping) GetMapping(domain string) *VanityDomainConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	
+	// Check if it's a vanity domain
+	if config, exists := s.vanityDomains[domain]; exists {
+		return config
+	}
+	
+	return nil
+}
+
+// HasDatasite checks if a datasite (email) is already in the mapping
+func (s *SubdomainMapping) HasDatasite(email string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	
+	_, exists := s.emailToHash[email]
+	return exists
+}

--- a/internal/server/datasite/subdomain_mapping_test.go
+++ b/internal/server/datasite/subdomain_mapping_test.go
@@ -1,0 +1,383 @@
+package datasite
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubdomainMapping(t *testing.T) {
+	t.Run("AddMapping", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add a mapping
+		hash := sm.AddMapping("alice@example.com")
+		assert.NotEmpty(t, hash)
+		assert.Equal(t, 16, len(hash)) // Hash should be 16 characters
+		
+		// Adding the same email should return the same hash
+		hash2 := sm.AddMapping("alice@example.com")
+		assert.Equal(t, hash, hash2)
+		
+		// Different email should get different hash
+		hash3 := sm.AddMapping("bob@example.com")
+		assert.NotEqual(t, hash, hash3)
+	})
+
+	t.Run("GetEmailByHash", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add mappings
+		hash1 := sm.AddMapping("alice@example.com")
+		hash2 := sm.AddMapping("bob@example.com")
+		
+		// Test valid lookups
+		email1, err := sm.GetEmailByHash(hash1)
+		assert.NoError(t, err)
+		assert.Equal(t, "alice@example.com", email1)
+		
+		email2, err := sm.GetEmailByHash(hash2)
+		assert.NoError(t, err)
+		assert.Equal(t, "bob@example.com", email2)
+		
+		// Test invalid lookup
+		_, err = sm.GetEmailByHash("invalid")
+		assert.ErrorIs(t, err, ErrSubdomainNotFound)
+	})
+
+	t.Run("GetHashByEmail", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add mappings
+		expectedHash := sm.AddMapping("alice@example.com")
+		
+		// Test valid lookup
+		hash, err := sm.GetHashByEmail("alice@example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedHash, hash)
+		
+		// Test invalid lookup
+		_, err = sm.GetHashByEmail("nonexistent@example.com")
+		assert.ErrorIs(t, err, ErrEmailNotFound)
+	})
+
+	t.Run("RemoveMapping", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add and remove mapping
+		hash := sm.AddMapping("alice@example.com")
+		sm.RemoveMapping("alice@example.com")
+		
+		// Verify both lookups fail
+		_, err := sm.GetEmailByHash(hash)
+		assert.ErrorIs(t, err, ErrSubdomainNotFound)
+		
+		_, err = sm.GetHashByEmail("alice@example.com")
+		assert.ErrorIs(t, err, ErrEmailNotFound)
+	})
+
+	t.Run("LoadMappings", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		emails := []string{
+			"alice@example.com",
+			"bob@example.com",
+			"charlie@example.com",
+		}
+		
+		sm.LoadMappings(emails)
+		
+		// Verify all mappings exist
+		for _, email := range emails {
+			hash, err := sm.GetHashByEmail(email)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, hash)
+			
+			retrievedEmail, err := sm.GetEmailByHash(hash)
+			assert.NoError(t, err)
+			assert.Equal(t, email, retrievedEmail)
+		}
+	})
+
+	t.Run("GetAllMappings", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add some mappings
+		hash1 := sm.AddMapping("alice@example.com")
+		hash2 := sm.AddMapping("bob@example.com")
+		
+		// Get all mappings
+		mappings := sm.GetAllMappings()
+		assert.Len(t, mappings, 2)
+		assert.Equal(t, "alice@example.com", mappings[hash1])
+		assert.Equal(t, "bob@example.com", mappings[hash2])
+	})
+
+	t.Run("ConcurrentAccess", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Test concurrent reads and writes
+		var wg sync.WaitGroup
+		numGoroutines := 10
+		
+		// Concurrent adds
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				email := string(rune('a'+i)) + "@example.com"
+				sm.AddMapping(email)
+			}(i)
+		}
+		
+		// Concurrent reads
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				email := string(rune('a'+i)) + "@example.com"
+				hash, _ := sm.GetHashByEmail(email)
+				sm.GetEmailByHash(hash)
+			}(i)
+		}
+		
+		// Concurrent get all
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sm.GetAllMappings()
+			}()
+		}
+		
+		wg.Wait()
+		
+		// Verify all mappings exist
+		mappings := sm.GetAllMappings()
+		assert.GreaterOrEqual(t, len(mappings), numGoroutines)
+	})
+}
+
+func TestVanityDomainMapping(t *testing.T) {
+	t.Run("AddVanityDomain", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add vanity domain mapping
+		sm.AddVanityDomain("alice.syftbox.local", "alice@example.com", "/blog")
+		
+		// Retrieve vanity domain
+		config, exists := sm.GetVanityDomain("alice.syftbox.local")
+		assert.True(t, exists)
+		assert.NotNil(t, config)
+		assert.Equal(t, "alice@example.com", config.Email)
+		assert.Equal(t, "/blog", config.Path)
+		
+		// Non-existent domain
+		_, exists = sm.GetVanityDomain("nonexistent.local")
+		assert.False(t, exists)
+	})
+
+	t.Run("VanityDomainWithDefaultPath", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add vanity domain with empty path (should default to /public)
+		sm.AddVanityDomain("alice.syftbox.local", "alice@example.com", "")
+		
+		config, exists := sm.GetVanityDomain("alice.syftbox.local")
+		assert.True(t, exists)
+		assert.Equal(t, "", config.Path) // Empty path means use default
+	})
+
+	t.Run("MultipleVanityDomains", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add multiple vanity domains for same user
+		sm.AddVanityDomain("blog.alice.local", "alice@example.com", "/blog")
+		sm.AddVanityDomain("portfolio.alice.local", "alice@example.com", "/portfolio")
+		sm.AddVanityDomain("projects.alice.local", "alice@example.com", "/projects/2024")
+		
+		// Verify all exist
+		config1, exists1 := sm.GetVanityDomain("blog.alice.local")
+		assert.True(t, exists1)
+		assert.Equal(t, "/blog", config1.Path)
+		
+		config2, exists2 := sm.GetVanityDomain("portfolio.alice.local")
+		assert.True(t, exists2)
+		assert.Equal(t, "/portfolio", config2.Path)
+		
+		config3, exists3 := sm.GetVanityDomain("projects.alice.local")
+		assert.True(t, exists3)
+		assert.Equal(t, "/projects/2024", config3.Path)
+	})
+
+	t.Run("RemoveVanityDomain", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add and remove vanity domain
+		sm.AddVanityDomain("alice.syftbox.local", "alice@example.com", "/blog")
+		sm.RemoveVanityDomain("alice.syftbox.local")
+		
+		// Verify it's gone
+		_, exists := sm.GetVanityDomain("alice.syftbox.local")
+		assert.False(t, exists)
+	})
+
+	t.Run("ClearVanityDomains", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add vanity domains for multiple users
+		sm.AddVanityDomain("alice1.local", "alice@example.com", "/blog")
+		sm.AddVanityDomain("alice2.local", "alice@example.com", "/portfolio")
+		sm.AddVanityDomain("bob.local", "bob@example.com", "/site")
+		
+		// Clear Alice's domains
+		sm.ClearVanityDomains("alice@example.com")
+		
+		// Verify Alice's domains are gone
+		_, exists1 := sm.GetVanityDomain("alice1.local")
+		assert.False(t, exists1)
+		_, exists2 := sm.GetVanityDomain("alice2.local")
+		assert.False(t, exists2)
+		
+		// Verify Bob's domain remains
+		config, exists := sm.GetVanityDomain("bob.local")
+		assert.True(t, exists)
+		assert.Equal(t, "bob@example.com", config.Email)
+	})
+
+	t.Run("GetAllVanityDomains", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add some vanity domains
+		sm.AddVanityDomain("alice.local", "alice@example.com", "/blog")
+		sm.AddVanityDomain("bob.local", "bob@example.com", "/site")
+		
+		// Get all domains
+		domains := sm.GetAllVanityDomains()
+		assert.Len(t, domains, 2)
+		
+		// Verify content
+		assert.Equal(t, "alice@example.com", domains["alice.local"].Email)
+		assert.Equal(t, "/blog", domains["alice.local"].Path)
+		assert.Equal(t, "bob@example.com", domains["bob.local"].Email)
+		assert.Equal(t, "/site", domains["bob.local"].Path)
+	})
+
+	t.Run("VanityDomainOverwrite", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add vanity domain
+		sm.AddVanityDomain("alice.local", "alice@example.com", "/old-path")
+		
+		// Overwrite with new path
+		sm.AddVanityDomain("alice.local", "alice@example.com", "/new-path")
+		
+		// Verify new path is used
+		config, exists := sm.GetVanityDomain("alice.local")
+		assert.True(t, exists)
+		assert.Equal(t, "/new-path", config.Path)
+	})
+
+	t.Run("VanityDomainOwnershipTracking", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add vanity domain for alice
+		sm.AddVanityDomain("cool.domain", "alice@example.com", "/site")
+		
+		// Try to claim same domain for bob (should overwrite)
+		sm.AddVanityDomain("cool.domain", "bob@example.com", "/blog")
+		
+		// Verify bob owns it now
+		config, exists := sm.GetVanityDomain("cool.domain")
+		assert.True(t, exists)
+		assert.Equal(t, "bob@example.com", config.Email)
+		assert.Equal(t, "/blog", config.Path)
+	})
+
+	t.Run("ConcurrentVanityDomainAccess", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Test concurrent reads and writes
+		var wg sync.WaitGroup
+		numGoroutines := 10
+		
+		// Concurrent adds
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				domain := string(rune('a'+i)) + ".local"
+				email := string(rune('a'+i)) + "@example.com"
+				sm.AddVanityDomain(domain, email, "/path")
+			}(i)
+		}
+		
+		// Concurrent reads
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				domain := string(rune('a'+i)) + ".local"
+				sm.GetVanityDomain(domain)
+			}(i)
+		}
+		
+		// Concurrent get all
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				sm.GetAllVanityDomains()
+			}()
+		}
+		
+		wg.Wait()
+		
+		// Verify all mappings exist
+		domains := sm.GetAllVanityDomains()
+		assert.GreaterOrEqual(t, len(domains), numGoroutines)
+	})
+}
+
+func TestHashSubdomainIntegration(t *testing.T) {
+	t.Run("HashAndVanityCoexistence", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add regular hash mapping
+		hash := sm.AddMapping("alice@example.com")
+		
+		// Add vanity domain for same user
+		sm.AddVanityDomain("alice.blog", "alice@example.com", "/blog")
+		
+		// Both should work independently
+		email, err := sm.GetEmailByHash(hash)
+		require.NoError(t, err)
+		assert.Equal(t, "alice@example.com", email)
+		
+		config, exists := sm.GetVanityDomain("alice.blog")
+		assert.True(t, exists)
+		assert.Equal(t, "alice@example.com", config.Email)
+	})
+
+	t.Run("RemoveMappingDoesNotAffectVanity", func(t *testing.T) {
+		sm := NewSubdomainMapping()
+		
+		// Add both mappings
+		sm.AddMapping("alice@example.com")
+		sm.AddVanityDomain("alice.blog", "alice@example.com", "/blog")
+		
+		// Remove hash mapping
+		sm.RemoveMapping("alice@example.com")
+		
+		// Hash mapping should be gone
+		_, err := sm.GetHashByEmail("alice@example.com")
+		assert.ErrorIs(t, err, ErrEmailNotFound)
+		
+		// Vanity domain should still exist
+		config, exists := sm.GetVanityDomain("alice.blog")
+		assert.True(t, exists)
+		assert.Equal(t, "alice@example.com", config.Email)
+	})
+}

--- a/internal/server/datasite/subdomain_update_test.go
+++ b/internal/server/datasite/subdomain_update_test.go
@@ -1,0 +1,59 @@
+package datasite
+
+import (
+	"testing"
+	
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubdomainMapping_HasDatasite(t *testing.T) {
+	sm := NewSubdomainMapping()
+	
+	// Test non-existent datasite
+	assert.False(t, sm.HasDatasite("test@example.com"))
+	
+	// Add a datasite
+	sm.AddMapping("test@example.com")
+	
+	// Test existing datasite
+	assert.True(t, sm.HasDatasite("test@example.com"))
+}
+
+func TestExtractDatasiteName_ValidPaths(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"alice@example.com/public/file.txt", "alice@example.com"},
+		{"bob@test.org/private/data.json", "bob@test.org"},
+		{"user@domain.co.uk/settings.yaml", "user@domain.co.uk"},
+		{"test@email.com", "test@email.com"},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			result := ExtractDatasiteName(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractDatasiteName_InvalidPaths(t *testing.T) {
+	tests := []struct {
+		path string
+	}{
+		{"not-an-email/file.txt"},
+		{"file.txt"},
+		{"/absolute/path/file.txt"},
+		{""},
+		{"user@/file.txt"}, // Invalid email
+		{"@domain.com/file.txt"}, // Invalid email
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			result := ExtractDatasiteName(tt.path)
+			assert.Empty(t, result)
+		})
+	}
+}

--- a/internal/server/handlers/blob/blob_handler.go
+++ b/internal/server/handlers/blob/blob_handler.go
@@ -3,6 +3,7 @@ package blob
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openmined/syftbox/internal/server/acl"
@@ -52,4 +53,29 @@ func (h *BlobHandler) checkPermissions(key string, user string, access acl.Acces
 	}
 
 	return nil
+}
+
+// IsReservedPath checks if a path contains reserved system paths
+func IsReservedPath(path string) bool {
+	// Clean the path
+	path = datasite.CleanPath(path)
+	
+	// Extract the part after the datasite name
+	parts := strings.Split(path, "/")
+	if len(parts) < 2 {
+		return false
+	}
+	
+	// Skip the datasite name (email) and check subsequent parts
+	for i := 1; i < len(parts); i++ {
+		part := strings.ToLower(parts[i])
+		// Check for reserved paths
+		if part == "api" || strings.HasPrefix(part, "api/") ||
+		   part == ".well-known" || strings.HasPrefix(part, ".well-known/") ||
+		   part == "_internal" || strings.HasPrefix(part, "_internal/") {
+			return true
+		}
+	}
+	
+	return false
 }

--- a/internal/server/handlers/blob/blob_handler.go
+++ b/internal/server/handlers/blob/blob_handler.go
@@ -61,7 +61,7 @@ func IsReservedPath(path string) bool {
 	path = datasite.CleanPath(path)
 	
 	// Extract the part after the datasite name
-	parts := strings.Split(path, "/")
+	parts := strings.Split(path, datasite.PathSep)
 	if len(parts) < 2 {
 		return false
 	}
@@ -70,9 +70,7 @@ func IsReservedPath(path string) bool {
 	for i := 1; i < len(parts); i++ {
 		part := strings.ToLower(parts[i])
 		// Check for reserved paths
-		if part == "api" || strings.HasPrefix(part, "api/") ||
-		   part == ".well-known" || strings.HasPrefix(part, ".well-known/") ||
-		   part == "_internal" || strings.HasPrefix(part, "_internal/") {
+		if part == "api" || part == ".well-known" || part == "_internal" {
 			return true
 		}
 	}

--- a/internal/server/handlers/blob/blob_handler_reserved_path_test.go
+++ b/internal/server/handlers/blob/blob_handler_reserved_path_test.go
@@ -1,0 +1,106 @@
+package blob
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsReservedPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		// Reserved paths that should be blocked
+		{
+			name:     "Direct api path",
+			path:     "alice@example.com/api/something",
+			expected: true,
+		},
+		{
+			name:     "API path in public directory",
+			path:     "alice@example.com/public/api/endpoint",
+			expected: true,
+		},
+		{
+			name:     "API path with subdirectory",
+			path:     "alice@example.com/public/api/v1/users",
+			expected: true,
+		},
+		{
+			name:     "Well-known path",
+			path:     "alice@example.com/public/.well-known/acme-challenge",
+			expected: true,
+		},
+		{
+			name:     "Internal path",
+			path:     "alice@example.com/public/_internal/config",
+			expected: true,
+		},
+		{
+			name:     "Case insensitive API",
+			path:     "alice@example.com/public/API/endpoint",
+			expected: true,
+		},
+		{
+			name:     "API in nested directory",
+			path:     "alice@example.com/public/nested/api/test",
+			expected: true,
+		},
+		
+		// Valid paths that should be allowed
+		{
+			name:     "Normal file",
+			path:     "alice@example.com/public/index.html",
+			expected: false,
+		},
+		{
+			name:     "File with api in name",
+			path:     "alice@example.com/public/myapi.txt",
+			expected: false,
+		},
+		{
+			name:     "Directory with api prefix",
+			path:     "alice@example.com/public/apitest/file.txt",
+			expected: false,
+		},
+		{
+			name:     "File named api.txt",
+			path:     "alice@example.com/public/api.txt",
+			expected: false,
+		},
+		{
+			name:     "Valid nested path",
+			path:     "alice@example.com/public/docs/readme.md",
+			expected: false,
+		},
+		{
+			name:     "Path with leading slash",
+			path:     "/alice@example.com/public/file.txt",
+			expected: false,
+		},
+		{
+			name:     "Short path",
+			path:     "alice@example.com",
+			expected: false,
+		},
+		{
+			name:     "Root path",
+			path:     "/",
+			expected: false,
+		},
+		{
+			name:     "Empty path",
+			path:     "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsReservedPath(tt.path)
+			assert.Equal(t, tt.expected, result, "Path: %s", tt.path)
+		})
+	}
+}

--- a/internal/server/handlers/blob/blob_handler_upload.go
+++ b/internal/server/handlers/blob/blob_handler_upload.go
@@ -34,6 +34,12 @@ func (h *BlobHandler) Upload(ctx *gin.Context) {
 		return
 	}
 
+	// Prevent creation of /api paths in datasites to avoid conflicts with system API endpoints
+	if IsReservedPath(req.Key) {
+		api.AbortWithError(ctx, http.StatusBadRequest, api.CodeDatasiteInvalidPath, fmt.Errorf("reserved path: %s", req.Key))
+		return
+	}
+
 	if err := h.checkPermissions(req.Key, user, acl.AccessWrite); err != nil {
 		api.AbortWithError(ctx, http.StatusForbidden, api.CodeAccessDenied, err)
 		return

--- a/internal/server/handlers/blob/blob_handler_upload_presigned.go
+++ b/internal/server/handlers/blob/blob_handler_upload_presigned.go
@@ -33,6 +33,18 @@ func (h *BlobHandler) UploadPresigned(ctx *gin.Context) {
 			continue
 		}
 
+		// Check for reserved paths
+		if IsReservedPath(key) {
+			errors = append(errors, &BlobAPIError{
+				SyftAPIError: api.SyftAPIError{
+					Code:    api.CodeDatasiteInvalidPath,
+					Message: "reserved path",
+				},
+				Key: key,
+			})
+			continue
+		}
+
 		if err := h.checkPermissions(key, user, acl.AccessWrite); err != nil {
 			errors = append(errors, &BlobAPIError{
 				SyftAPIError: api.SyftAPIError{

--- a/internal/server/handlers/explorer/explorer_handler.go
+++ b/internal/server/handlers/explorer/explorer_handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openmined/syftbox/internal/server/acl"
 	"github.com/openmined/syftbox/internal/server/blob"
 	"github.com/openmined/syftbox/internal/server/handlers/api"
+	"github.com/openmined/syftbox/internal/server/middlewares"
 )
 
 //go:embed index.html.tmpl
@@ -56,9 +57,51 @@ func New(svc *blob.BlobService, acl *acl.ACLService) *ExplorerHandler {
 }
 
 func (e *ExplorerHandler) Handler(c *gin.Context) {
-	path := strings.TrimPrefix(c.Param("filepath"), "/")
+	// For subdomain requests that were rewritten, use the full request path
+	// Otherwise use the filepath parameter from the route
+	path := ""
+	if middlewares.IsSubdomainRequest(c) {
+		// Use the rewritten path, removing the leading /datasites/
+		path = strings.TrimPrefix(c.Request.URL.Path, "/datasites/")
+	} else {
+		path = strings.TrimPrefix(c.Param("filepath"), "/")
+	}
+	
+	// For subdomain requests, we need to handle the path differently
+	// The middleware has already rewritten the path to /datasites/{email}/public/*
+	// but we need to be aware of this for proper display and navigation
+	if middlewares.IsSubdomainRequest(c) {
+		// The path already includes the datasite prefix from the middleware rewrite
+		// We need to store this information for proper link generation in templates
+		c.Set("subdomain_mode", true)
+		if email, exists := middlewares.GetSubdomainEmail(c); exists {
+			c.Set("datasite_email", email)
+		}
+	}
+	
 	contents := e.listContents(path)
 	if contents.IsDir || contents.EmptyDir() {
+		// Check if index.html exists in this directory
+		indexPath := path
+		if !strings.HasSuffix(indexPath, "/") {
+			indexPath += "/"
+		}
+		indexPath += "index.html"
+		
+		// Try to find index.html in the directory
+		if _, exists := e.blob.Index().Get(indexPath); exists {
+			// Check if user has access to the index.html
+			if err := e.acl.CanAccess(
+				&acl.User{ID: aclspec.Everyone},
+				&acl.File{Path: indexPath},
+				acl.AccessRead,
+			); err == nil {
+				// Serve index.html instead of directory listing
+				e.serveFile(c, indexPath)
+				return
+			}
+		}
+		// Show directory listing
 		e.serveDir(c, path, contents)
 	} else {
 		e.serveFile(c, path)
@@ -80,12 +123,10 @@ func (e *ExplorerHandler) listContents(prefix string) *directoryContents {
 
 	var filterPrefix string
 	if datasite == "" {
-		// root index
-		filterPrefix = "*/public/" + aclspec.AclFileName
-	} else if !strings.HasPrefix(prefix, datasite+"/public/") {
-		// force public dirs
-		filterPrefix = datasite + "/public/"
+		// root index - show all datasites with ACL files
+		filterPrefix = "*/" + aclspec.AclFileName
 	} else {
+		// Show content based on the actual path, let ACL system control access
 		filterPrefix = prefix
 	}
 
@@ -152,10 +193,19 @@ func (e *ExplorerHandler) serveDir(c *gin.Context, path string, contents *direct
 		path = "/" + path
 	}
 
+	// Check if this is a subdomain request
+	isSubdomain := middlewares.IsSubdomainRequest(c)
+	basePath := "/datasites"
+	if isSubdomain {
+		basePath = ""
+	}
+
 	data := indexData{
-		Path:    path,
-		Folders: contents.Folders,
-		Files:   contents.Files,
+		Path:        path,
+		Folders:     contents.Folders,
+		Files:       contents.Files,
+		IsSubdomain: isSubdomain,
+		BasePath:    basePath,
 	}
 
 	// Generate an HTML response

--- a/internal/server/handlers/explorer/explorer_handler_status_test.go
+++ b/internal/server/handlers/explorer/explorer_handler_status_test.go
@@ -1,0 +1,94 @@
+package explorer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"text/template"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExplorerHandler_StatusCodes(t *testing.T) {
+	// Test that serve404 returns 404 status code
+	t.Run("serve404 returns 404 status", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		
+		// Create a minimal handler with templates
+		handler := &ExplorerHandler{
+			tpl404: testTemplate404(),
+		}
+		
+		// Create test context
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		
+		// Call serve404
+		handler.serve404(c, "test/file.html")
+		
+		// Assert 404 status code
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Contains(t, w.Body.String(), "404")
+		assert.Contains(t, w.Body.String(), "test/file.html")
+	})
+	
+	// Test that serveDir returns 200 status code
+	t.Run("serveDir returns 200 status", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		
+		// Create a minimal handler with templates
+		handler := &ExplorerHandler{
+			tplIndex: testTemplateIndex(),
+		}
+		
+		// Create test context
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		
+		// Create directory contents
+		contents := &directoryContents{
+			IsDir:   true,
+			Files:   nil,
+			Folders: []string{"folder1", "folder2"},
+		}
+		
+		// Call serveDir
+		handler.serveDir(c, "/test/", contents)
+		
+		// Assert 200 status code (default when no error)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "Index of")
+		assert.Contains(t, w.Body.String(), "folder1")
+		assert.Contains(t, w.Body.String(), "folder2")
+	})
+}
+
+// Helper to create test 404 template
+func testTemplate404() *template.Template {
+	tmpl := `<!DOCTYPE html>
+<html>
+<head><title>404 Not Found</title></head>
+<body>
+<h1>404 Not Found</h1>
+<p>The requested file {{.Key}} was not found.</p>
+</body>
+</html>`
+	return template.Must(template.New("404").Parse(tmpl))
+}
+
+// Helper to create test index template
+func testTemplateIndex() *template.Template {
+	tmpl := `<!DOCTYPE html>
+<html>
+<head><title>Index of {{.Path}}</title></head>
+<body>
+<h1>Index of {{.Path}}</h1>
+<ul>
+{{range .Folders}}<li>{{.}}/</li>{{end}}
+{{range .Files}}<li>{{.Key}}</li>{{end}}
+</ul>
+</body>
+</html>`
+	return template.Must(template.New("index").Parse(tmpl))
+}

--- a/internal/server/handlers/explorer/explorer_handler_types.go
+++ b/internal/server/handlers/explorer/explorer_handler_types.go
@@ -4,9 +4,11 @@ import "github.com/openmined/syftbox/internal/server/blob"
 
 // indexData contains data for the index template
 type indexData struct {
-	Path    string
-	Folders []string
-	Files   []*blob.BlobInfo
+	Path        string
+	Folders     []string
+	Files       []*blob.BlobInfo
+	IsSubdomain bool   // Whether this is served via subdomain
+	BasePath    string // Base path for links (empty for subdomain, "/datasites" for direct)
 }
 
 // directoryContents holds the result of listing a directory

--- a/internal/server/handlers/explorer/index.html.tmpl
+++ b/internal/server/handlers/explorer/index.html.tmpl
@@ -150,14 +150,14 @@
       </tr>
       {{range .Folders}}
       <tr>
-        <td><a href="/datasites{{$.Path}}{{.}}/"><span class="icon">📁</span>{{.}}/</a></td>
+        <td><a href="{{if $.IsSubdomain}}./{{.}}/{{else}}/datasites{{$.Path}}{{.}}/{{end}}"><span class="icon">📁</span>{{.}}/</a></td>
         <td class="size-column">Directory</td>
         <td class="date-column">-</td>
       </tr>
       {{end}}
       {{range .Files}}
       <tr>
-        <td><a href="/datasites/{{.Key}}"><span class="icon">📄</span>{{basename .Key}}</a></td>
+        <td><a href="{{if $.IsSubdomain}}./{{basename .Key}}{{else}}/datasites/{{.Key}}{{end}}"><span class="icon">📄</span>{{basename .Key}}</a></td>
         <td class="size-column">{{humanizeSize .Size}}</td>
         <td class="date-column">{{.LastModified}}</td>
       </tr>

--- a/internal/server/middlewares/cors.go
+++ b/internal/server/middlewares/cors.go
@@ -1,19 +1,81 @@
 package middlewares
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )
 
-// server cors config
-var corsConfig = cors.Config{
-	AllowOrigins:     []string{"*"},
-	AllowHeaders:     []string{"*"},
-	AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-	AllowCredentials: false,
-	AllowWebSockets:  true,
+// CORS returns a CORS middleware that provides subdomain isolation
+func CORS() gin.HandlerFunc {
+	// Default config for non-subdomain requests
+	defaultConfig := cors.Config{
+		AllowOrigins:     []string{"*"},
+		AllowHeaders:     []string{"*"},
+		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+		AllowCredentials: false,
+		AllowWebSockets:  true,
+	}
+
+	// Create custom CORS handler
+	return func(c *gin.Context) {
+		origin := c.Request.Header.Get("Origin")
+		
+		// Check if this is a subdomain request
+		if IsSubdomainRequest(c) {
+			// For subdomain requests, apply strict CORS policy
+			// Only allow same-origin requests with credentials
+			c.Header("Access-Control-Allow-Origin", origin)
+			c.Header("Access-Control-Allow-Credentials", "true")
+			c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+			c.Header("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, X-CSRF-Token")
+			c.Header("Access-Control-Max-Age", "86400")
+			
+			// Add Content Security Policy for subdomain isolation
+			c.Header("Content-Security-Policy", "default-src 'self' https://*.syftbox.net; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';")
+			
+			// For preflight requests
+			if c.Request.Method == http.MethodOptions {
+				c.AbortWithStatus(http.StatusNoContent)
+				return
+			}
+		} else {
+			// For non-subdomain requests, use the default CORS handler
+			corsHandler := cors.New(defaultConfig)
+			corsHandler(c)
+			return
+		}
+		
+		c.Next()
+	}
 }
 
-func CORS() gin.HandlerFunc {
-	return cors.New(corsConfig)
+// SetSubdomainSecurityHeaders sets additional security headers for subdomain requests
+func SetSubdomainSecurityHeaders(c *gin.Context) {
+	if IsSubdomainRequest(c) {
+		// Prevent clickjacking
+		c.Header("X-Frame-Options", "SAMEORIGIN")
+		
+		// Prevent MIME type sniffing
+		c.Header("X-Content-Type-Options", "nosniff")
+		
+		// Enable XSS protection
+		c.Header("X-XSS-Protection", "1; mode=block")
+		
+		// Referrer policy for privacy
+		c.Header("Referrer-Policy", "same-origin")
+		
+		// Feature policy to restrict features
+		c.Header("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
+		
+		// Set cookie attributes for subdomain
+		if email, exists := GetSubdomainEmail(c); exists {
+			// Create a unique cookie prefix for this subdomain
+			cookiePrefix := strings.ReplaceAll(email, "@", "_at_")
+			cookiePrefix = strings.ReplaceAll(cookiePrefix, ".", "_")
+			c.Set("cookie_prefix", cookiePrefix)
+		}
+	}
 }

--- a/internal/server/middlewares/subdomain.go
+++ b/internal/server/middlewares/subdomain.go
@@ -1,0 +1,267 @@
+package middlewares
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	// SubdomainEmailKey stores the extracted email in gin context
+	SubdomainEmailKey = "subdomain_email"
+	// SubdomainHashKey stores the subdomain hash in gin context
+	SubdomainHashKey = "subdomain_hash"
+	// IsSubdomainRequestKey indicates if this is a subdomain request
+	IsSubdomainRequestKey = "is_subdomain_request"
+)
+
+// SubdomainConfig holds configuration for subdomain middleware
+type SubdomainConfig struct {
+	// MainDomain is the base domain (e.g., "syftbox.net")
+	MainDomain string
+	// GetVanityDomainFunc returns vanity domain config (now handles all domains)
+	GetVanityDomainFunc func(domain string) (email string, path string, exists bool)
+}
+
+// SubdomainMiddleware extracts subdomain and rewrites paths for datasite access
+func SubdomainMiddleware(config SubdomainConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		host := c.Request.Host
+		
+		// Debug logging
+		c.Set("debug_original_host", host)
+		
+		// Remove port if present
+		if idx := strings.LastIndex(host, ":"); idx != -1 {
+			host = host[:idx]
+		}
+		
+		// Debug logging
+		c.Set("debug_host_no_port", host)
+		c.Set("debug_main_domain", config.MainDomain)
+
+		// First check if this is a vanity domain
+		if config.GetVanityDomainFunc != nil {
+			if email, path, exists := config.GetVanityDomainFunc(host); exists {
+				c.Set(IsSubdomainRequestKey, true)
+				c.Set(SubdomainEmailKey, email)
+				c.Set("is_vanity_domain", true)
+				c.Set("vanity_domain", host)
+
+				// Rewrite the path
+				originalPath := c.Request.URL.Path
+				
+				// If accessing API endpoints, don't rewrite
+				if strings.HasPrefix(originalPath, "/api/") {
+					c.Next()
+					return
+				}
+
+				// Rewrite path to datasite format with custom path
+				// Remove leading slash from original path
+				if originalPath == "/" {
+					originalPath = ""
+				} else if strings.HasPrefix(originalPath, "/") {
+					originalPath = originalPath[1:]
+				}
+
+				// Ensure path starts with /
+				if !strings.HasPrefix(path, "/") {
+					path = "/" + path
+				}
+
+				// Construct new path - vanity domain points to custom path
+				// Handle root path case to avoid double slashes
+				var newPath string
+				if path == "/" {
+					// Root path case: point to datasite root
+					if originalPath == "" {
+						newPath = "/datasites/" + email + "/"
+					} else {
+						newPath = "/datasites/" + email + "/" + originalPath
+					}
+				} else {
+					// Custom path case
+					if originalPath == "" {
+						newPath = "/datasites/" + email + path + "/"
+					} else {
+						newPath = "/datasites/" + email + path + "/" + originalPath
+					}
+				}
+				c.Request.URL.Path = newPath
+
+				// Store original path for logging/debugging
+				c.Set("original_path", originalPath)
+				c.Set("rewritten_path", newPath)
+				
+				c.Next()
+				return
+			}
+		}
+
+		// Check if this is a hash-based subdomain
+		if config.MainDomain != "" && isSubdomainRequest(host, config.MainDomain) {
+			subdomain := extractSubdomain(host, config.MainDomain)
+			
+			// Debug logging
+			c.Set("debug_is_subdomain", true)
+			c.Set("debug_extracted_subdomain", subdomain)
+			
+			// Check if the subdomain is a valid hash (16 character hex)
+			if len(subdomain) == 16 && isHexString(subdomain) {
+				// Debug logging
+				c.Set("debug_is_valid_hash", true)
+				// Try to get the email for this hash
+				if config.GetVanityDomainFunc != nil {
+					// The GetVanityDomainFunc also handles hash lookups
+					if email, path, exists := config.GetVanityDomainFunc(host); exists {
+						c.Set(IsSubdomainRequestKey, true)
+						c.Set(SubdomainEmailKey, email)
+						c.Set(SubdomainHashKey, subdomain)
+						c.Set("is_hash_subdomain", true)
+						
+						// Rewrite the path
+						originalPath := c.Request.URL.Path
+						
+						// If accessing API endpoints, don't rewrite
+						if strings.HasPrefix(originalPath, "/api/") {
+							c.Next()
+							return
+						}
+						
+						// Remove leading slash from original path
+						if originalPath == "/" {
+							originalPath = ""
+						} else if strings.HasPrefix(originalPath, "/") {
+							originalPath = originalPath[1:]
+						}
+						
+						// Ensure path starts with /
+						if !strings.HasPrefix(path, "/") {
+							path = "/" + path
+						}
+						
+						// Construct new path
+						var newPath string
+						if path == "/" || path == "/public" {
+							// Default hash subdomain points to /public
+							if originalPath == "" {
+								newPath = "/datasites/" + email + "/public/"
+							} else {
+								newPath = "/datasites/" + email + "/public/" + originalPath
+							}
+						} else {
+							// Custom path case
+							if originalPath == "" {
+								newPath = "/datasites/" + email + path + "/"
+							} else {
+								newPath = "/datasites/" + email + path + "/" + originalPath
+							}
+						}
+						c.Request.URL.Path = newPath
+						
+						// Store original path for logging/debugging
+						c.Set("original_path", originalPath)
+						c.Set("rewritten_path", newPath)
+						
+						c.Next()
+						return
+					}
+				}
+			}
+		}
+
+		// If we reach here, it's not a recognized domain
+		c.Set(IsSubdomainRequestKey, false)
+
+		c.Next()
+	}
+}
+
+// isSubdomainRequest checks if the host is a subdomain of the main domain
+func isSubdomainRequest(host, mainDomain string) bool {
+	// Strip port if present
+	if colonIndex := strings.Index(host, ":"); colonIndex != -1 {
+		host = host[:colonIndex]
+	}
+	
+	// Check if host ends with main domain
+	if !strings.HasSuffix(host, mainDomain) {
+		return false
+	}
+
+	// Check if there's a subdomain
+	prefix := strings.TrimSuffix(host, "."+mainDomain)
+	return prefix != "" && prefix != host && prefix != "www"
+}
+
+// extractSubdomain extracts the subdomain from the host
+func extractSubdomain(host, mainDomain string) string {
+	// Strip port if present
+	if colonIndex := strings.Index(host, ":"); colonIndex != -1 {
+		host = host[:colonIndex]
+	}
+	
+	if !strings.HasSuffix(host, mainDomain) {
+		return ""
+	}
+	
+	prefix := strings.TrimSuffix(host, "."+mainDomain)
+	if prefix == host {
+		return ""
+	}
+	
+	return prefix
+}
+
+// isHexString checks if a string contains only hexadecimal characters
+func isHexString(s string) bool {
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+// EmailToSubdomainHash generates a subdomain-safe hash from an email address
+func EmailToSubdomainHash(email string) string {
+	// Normalize email to lowercase
+	email = strings.ToLower(strings.TrimSpace(email))
+	
+	// Create SHA256 hash
+	hash := sha256.Sum256([]byte(email))
+	
+	// Convert to hex and take first 16 characters for subdomain
+	// This provides sufficient uniqueness while keeping subdomain length reasonable
+	return hex.EncodeToString(hash[:])[:16]
+}
+
+// IsSubdomainRequest checks if the current request is a subdomain request
+func IsSubdomainRequest(c *gin.Context) bool {
+	isSubdomain, exists := c.Get(IsSubdomainRequestKey)
+	if !exists {
+		return false
+	}
+	return isSubdomain.(bool)
+}
+
+// GetSubdomainEmail retrieves the email associated with the subdomain
+func GetSubdomainEmail(c *gin.Context) (string, bool) {
+	email, exists := c.Get(SubdomainEmailKey)
+	if !exists {
+		return "", false
+	}
+	return email.(string), true
+}
+
+// GetSubdomainHash retrieves the subdomain hash from context
+func GetSubdomainHash(c *gin.Context) (string, bool) {
+	hash, exists := c.Get(SubdomainHashKey)
+	if !exists {
+		return "", false
+	}
+	return hash.(string), true
+}

--- a/internal/server/middlewares/subdomain_test.go
+++ b/internal/server/middlewares/subdomain_test.go
@@ -1,0 +1,575 @@
+package middlewares
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubdomainMiddleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		host           string
+		path           string
+		mainDomain     string
+		vanityDomains  map[string]struct{ email, path string }
+		expectedPath   string
+		expectedEmail  string
+		expectedStatus int
+		isSubdomain    bool
+		isVanity       bool
+	}{
+		// Hash subdomain tests
+		{
+			name:       "Hash subdomain with file",
+			host:       "ff8d9819fc0e12bf.syftbox.net",
+			path:       "/index.html",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"ff8d9819fc0e12bf.syftbox.net": {"alice@example.com", "/public"},
+			},
+			expectedPath:   "/datasites/alice@example.com/public/index.html",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		{
+			name:       "Hash subdomain with root path",
+			host:       "ff8d9819fc0e12bf.syftbox.net",
+			path:       "/",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"ff8d9819fc0e12bf.syftbox.net": {"alice@example.com", "/public"},
+			},
+			expectedPath:   "/datasites/alice@example.com/public/",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		{
+			name:       "Hash subdomain with nested path",
+			host:       "ff8d9819fc0e12bf.syftbox.net",
+			path:       "/docs/readme.md",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"ff8d9819fc0e12bf.syftbox.net": {"alice@example.com", "/public"},
+			},
+			expectedPath:   "/datasites/alice@example.com/public/docs/readme.md",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		// Vanity domain tests
+		{
+			name:       "Vanity domain with custom path",
+			host:       "alice.blog",
+			path:       "/post.html",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"alice.blog": {"alice@example.com", "/blog"},
+			},
+			expectedPath:   "/datasites/alice@example.com/blog/post.html",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		{
+			name:       "Vanity domain with root path pointing to subdirectory",
+			host:       "alice.blog",
+			path:       "/",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"alice.blog": {"alice@example.com", "/blog"},
+			},
+			expectedPath:   "/datasites/alice@example.com/blog/",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		{
+			name:       "Vanity domain with nested custom path",
+			host:       "projects.alice.dev",
+			path:       "/demo/index.html",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"projects.alice.dev": {"alice@example.com", "/projects/2024"},
+			},
+			expectedPath:   "/datasites/alice@example.com/projects/2024/demo/index.html",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		{
+			name:       "Vanity domain pointing to root",
+			host:       "alice.site",
+			path:       "/about.html",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"alice.site": {"alice@example.com", "/"},
+			},
+			expectedPath:   "/datasites/alice@example.com/about.html",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		// API endpoint tests
+		{
+			name:       "API endpoint on hash subdomain",
+			host:       "ff8d9819fc0e12bf.syftbox.net",
+			path:       "/api/v1/status",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"ff8d9819fc0e12bf.syftbox.net": {"alice@example.com", "/public"},
+			},
+			expectedPath:   "/api/v1/status", // Should not be rewritten
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		{
+			name:       "API endpoint on vanity domain",
+			host:       "alice.blog",
+			path:       "/api/v1/posts",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"alice.blog": {"alice@example.com", "/blog"},
+			},
+			expectedPath:   "/api/v1/posts", // Should not be rewritten
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		// Non-subdomain tests
+		{
+			name:           "Main domain request",
+			host:           "syftbox.net",
+			path:           "/index.html",
+			mainDomain:     "syftbox.net",
+			vanityDomains:  map[string]struct{ email, path string }{},
+			expectedPath:   "/index.html",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    false,
+			isVanity:       false,
+		},
+		{
+			name:           "Unknown subdomain",
+			host:           "unknown.syftbox.net",
+			path:           "/index.html",
+			mainDomain:     "syftbox.net",
+			vanityDomains:  map[string]struct{ email, path string }{},
+			expectedPath:   "/index.html",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    false,
+			isVanity:       false,
+		},
+		{
+			name:           "Unknown vanity domain",
+			host:           "unknown.site",
+			path:           "/index.html",
+			mainDomain:     "syftbox.net",
+			vanityDomains:  map[string]struct{ email, path string }{},
+			expectedPath:   "/index.html",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    false,
+			isVanity:       false,
+		},
+		{
+			name:           "Different domain entirely",
+			host:           "example.com",
+			path:           "/index.html",
+			mainDomain:     "syftbox.net",
+			vanityDomains:  map[string]struct{ email, path string }{},
+			expectedPath:   "/index.html",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    false,
+			isVanity:       false,
+		},
+		// Port handling
+		{
+			name:       "Subdomain with port",
+			host:       "ff8d9819fc0e12bf.syftbox.net:8080",
+			path:       "/index.html",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"ff8d9819fc0e12bf.syftbox.net": {"alice@example.com", "/public"},
+			},
+			expectedPath:   "/datasites/alice@example.com/public/index.html",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		{
+			name:       "Vanity domain with port",
+			host:       "alice.blog:3000",
+			path:       "/post.html",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"alice.blog": {"alice@example.com", "/blog"},
+			},
+			expectedPath:   "/datasites/alice@example.com/blog/post.html",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		// Edge cases
+		{
+			name:       "Empty path on vanity domain",
+			host:       "alice.blog",
+			path:       "/",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"alice.blog": {"alice@example.com", "/blog"},
+			},
+			expectedPath:   "/datasites/alice@example.com/blog/",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+		{
+			name:       "Double slash prevention",
+			host:       "alice.blog",
+			path:       "//double//slash//",
+			mainDomain: "syftbox.net",
+			vanityDomains: map[string]struct{ email, path string }{
+				"alice.blog": {"alice@example.com", "/blog"},
+			},
+			expectedPath:   "/datasites/alice@example.com/blog//double//slash//",
+			expectedEmail:  "alice@example.com",
+			expectedStatus: http.StatusOK,
+			isSubdomain:    true,
+			isVanity:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			
+			// Mock vanity domain function
+			vanityDomainFunc := func(domain string) (string, string, bool) {
+				if config, exists := tt.vanityDomains[domain]; exists {
+					return config.email, config.path, true
+				}
+				return "", "", false
+			}
+
+			config := SubdomainConfig{
+				MainDomain:          tt.mainDomain,
+				GetVanityDomainFunc: vanityDomainFunc,
+			}
+
+			router.Use(SubdomainMiddleware(config))
+			
+			// Test handler
+			router.GET("/*path", func(c *gin.Context) {
+				actualPath := c.Request.URL.Path
+				assert.Equal(t, tt.expectedPath, actualPath)
+				
+				if tt.isSubdomain {
+					assert.True(t, IsSubdomainRequest(c))
+					if tt.expectedEmail != "" {
+						email, exists := GetSubdomainEmail(c)
+						assert.True(t, exists)
+						assert.Equal(t, tt.expectedEmail, email)
+					}
+					
+					// Check vanity domain flag
+					isVanity, _ := c.Get("is_vanity_domain")
+					if tt.isVanity {
+						assert.True(t, isVanity.(bool))
+						vanityDomain, _ := c.Get("vanity_domain")
+						// Remove port for comparison
+						expectedDomain := tt.host
+						if idx := strings.LastIndex(expectedDomain, ":"); idx != -1 {
+							expectedDomain = expectedDomain[:idx]
+						}
+						assert.Equal(t, expectedDomain, vanityDomain)
+					}
+				} else {
+					assert.False(t, IsSubdomainRequest(c))
+				}
+				
+				c.Status(http.StatusOK)
+			})
+
+			// Create request
+			req := httptest.NewRequest("GET", tt.path, nil)
+			req.Host = tt.host
+			
+			// Perform request
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			
+			// Check status
+			assert.Equal(t, tt.expectedStatus, w.Code)
+		})
+	}
+}
+
+func TestEmailToSubdomainHash(t *testing.T) {
+	tests := []struct {
+		email    string
+		expected string
+	}{
+		{
+			email:    "alice@example.com",
+			expected: "ff8d9819fc0e12bf", // First 16 chars of SHA256 hash
+		},
+		{
+			email:    "ALICE@EXAMPLE.COM", // Should be case-insensitive
+			expected: "ff8d9819fc0e12bf",
+		},
+		{
+			email:    "  alice@example.com  ", // Should trim spaces
+			expected: "ff8d9819fc0e12bf",
+		},
+		{
+			email:    "bob@example.com",
+			expected: "5ff860bf1190596c", // Different hash
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.email, func(t *testing.T) {
+			hash := EmailToSubdomainHash(tt.email)
+			assert.Equal(t, tt.expected, hash)
+			assert.Equal(t, 16, len(hash)) // Hash should always be 16 characters
+		})
+	}
+}
+
+func TestExtractSubdomain(t *testing.T) {
+	tests := []struct {
+		host       string
+		mainDomain string
+		expected   string
+	}{
+		{"abc123.syftbox.net", "syftbox.net", "abc123"},
+		{"www.syftbox.net", "syftbox.net", "www"},
+		{"syftbox.net", "syftbox.net", ""},
+		{"example.com", "syftbox.net", ""},
+		{"deep.sub.syftbox.net", "syftbox.net", "deep.sub"},
+		{"", "syftbox.net", ""},
+		{"abc123.syftbox.net:8080", "syftbox.net", "abc123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			result := extractSubdomain(tt.host, tt.mainDomain)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsSubdomainRequest(t *testing.T) {
+	tests := []struct {
+		host       string
+		mainDomain string
+		expected   bool
+	}{
+		{"abc123.syftbox.net", "syftbox.net", true},
+		{"www.syftbox.net", "syftbox.net", false}, // www is excluded
+		{"syftbox.net", "syftbox.net", false},
+		{"example.com", "syftbox.net", false},
+		{"", "syftbox.net", false},
+		{"deep.sub.syftbox.net", "syftbox.net", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			result := isSubdomainRequest(tt.host, tt.mainDomain)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSubdomainContextSetting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	
+	router := gin.New()
+	
+	// Mock vanity domain function
+	vanityDomainFunc := func(domain string) (string, string, bool) {
+		if domain == "alice.blog" {
+			return "alice@example.com", "/blog", true
+		}
+		return "", "", false
+	}
+	
+	config := SubdomainConfig{
+		MainDomain:          "syftbox.net",
+		GetVanityDomainFunc: vanityDomainFunc,
+	}
+	
+	router.Use(SubdomainMiddleware(config))
+	
+	// Test handler that checks context values
+	router.GET("/*path", func(c *gin.Context) {
+		// Check subdomain context
+		isSubdomain := IsSubdomainRequest(c)
+		assert.True(t, isSubdomain)
+		
+		// Check email
+		email, exists := GetSubdomainEmail(c)
+		assert.True(t, exists)
+		assert.Equal(t, "alice@example.com", email)
+		
+		// Check vanity domain flag
+		isVanity, exists := c.Get("is_vanity_domain")
+		assert.True(t, exists)
+		assert.True(t, isVanity.(bool))
+		
+		// Check vanity domain
+		vanityDomain, exists := c.Get("vanity_domain")
+		assert.True(t, exists)
+		assert.Equal(t, "alice.blog", vanityDomain)
+		
+		// Check path rewriting
+		originalPath, exists := c.Get("original_path")
+		assert.True(t, exists)
+		assert.Equal(t, "index.html", originalPath)
+		
+		rewrittenPath, exists := c.Get("rewritten_path")
+		assert.True(t, exists)
+		assert.Equal(t, "/datasites/alice@example.com/blog/index.html", rewrittenPath)
+		
+		c.Status(http.StatusOK)
+	})
+	
+	// Create request
+	req := httptest.NewRequest("GET", "/index.html", nil)
+	req.Host = "alice.blog"
+	
+	// Perform request
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	
+	// Check status
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPathRewritingEdgeCases(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	
+	tests := []struct {
+		name         string
+		host         string
+		originalPath string
+		vanityPath   string
+		expectedPath string
+	}{
+		{
+			name:         "Root to root",
+			host:         "alice.site",
+			originalPath: "/",
+			vanityPath:   "/",
+			expectedPath: "/datasites/alice@example.com/",
+		},
+		{
+			name:         "File at root",
+			host:         "alice.site",
+			originalPath: "/index.html",
+			vanityPath:   "/",
+			expectedPath: "/datasites/alice@example.com/index.html",
+		},
+		{
+			name:         "Root to subdirectory",
+			host:         "alice.blog",
+			originalPath: "/",
+			vanityPath:   "/blog",
+			expectedPath: "/datasites/alice@example.com/blog/",
+		},
+		{
+			name:         "File in subdirectory",
+			host:         "alice.blog",
+			originalPath: "/post.html",
+			vanityPath:   "/blog",
+			expectedPath: "/datasites/alice@example.com/blog/post.html",
+		},
+		{
+			name:         "Nested path",
+			host:         "alice.projects",
+			originalPath: "/2024/demo/index.html",
+			vanityPath:   "/projects",
+			expectedPath: "/datasites/alice@example.com/projects/2024/demo/index.html",
+		},
+		{
+			name:         "Empty original path",
+			host:         "alice.blog",
+			originalPath: "/",
+			vanityPath:   "/blog",
+			expectedPath: "/datasites/alice@example.com/blog/",
+		},
+		{
+			name:         "Path without leading slash",
+			host:         "alice.blog",
+			originalPath: "/post.html",
+			vanityPath:   "/blog",
+			expectedPath: "/datasites/alice@example.com/blog/post.html",
+		},
+		{
+			name:         "Vanity path without leading slash",
+			host:         "alice.blog",
+			originalPath: "/post.html",
+			vanityPath:   "blog",
+			expectedPath: "/datasites/alice@example.com/blog/post.html",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			
+			// Mock vanity domain function
+			vanityDomainFunc := func(domain string) (string, string, bool) {
+				if domain == tt.host {
+					return "alice@example.com", tt.vanityPath, true
+				}
+				return "", "", false
+			}
+			
+			config := SubdomainConfig{
+				MainDomain:          "syftbox.net",
+				GetVanityDomainFunc: vanityDomainFunc,
+			}
+			
+			router.Use(SubdomainMiddleware(config))
+			
+			// Test handler
+			router.GET("/*path", func(c *gin.Context) {
+				actualPath := c.Request.URL.Path
+				assert.Equal(t, tt.expectedPath, actualPath)
+				c.Status(http.StatusOK)
+			})
+			
+			// Create request
+			req := httptest.NewRequest("GET", tt.originalPath, nil)
+			req.Host = tt.host
+			
+			// Perform request
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			
+			// Check status
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -25,16 +26,45 @@ import (
 //go:embed handlers/send/*.html
 var templateFS embed.FS
 
-func SetupRoutes(svc *Services, hub *ws.WebsocketHub, httpsEnabled bool) http.Handler {
+func SetupRoutes(cfg *Config, svc *Services, hub *ws.WebsocketHub) http.Handler {
 	r := gin.New()
 
 	// --------------------------- middlewares ---------------------------
 
 	r.Use(gin.Recovery())
 	r.Use(middlewares.Logger())
+	
+	// Add subdomain middleware if domain is configured
+	if cfg.HTTP.Domain != "" {
+		subdomainMapping := svc.Datasite.GetSubdomainMapping()
+		subdomainConfig := middlewares.SubdomainConfig{
+			MainDomain: cfg.HTTP.Domain,
+			GetVanityDomainFunc: func(domain string) (email string, path string, exists bool) {
+				// First check if it's a vanity domain
+				if config, ok := subdomainMapping.GetVanityDomain(domain); ok {
+					return config.Email, config.Path, true
+				}
+				
+				// Check if it's a hash subdomain (e.g., ff8d9819fc0e12bf.syftbox.local)
+				if idx := strings.Index(domain, "."); idx > 0 && idx == 16 {
+					hash := domain[:idx]
+					// Check if this is a valid hash subdomain
+					if email, err := subdomainMapping.GetEmailByHash(hash); err == nil {
+						// Hash subdomains default to /public path
+						return email, "/public", true
+					}
+				}
+				
+				return "", "", false
+			},
+		}
+		r.Use(middlewares.SubdomainMiddleware(subdomainConfig))
+	}
+	
 	r.Use(middlewares.CORS())
+	r.Use(middlewares.SetSubdomainSecurityHeaders)
 	r.Use(middlewares.GZIP())
-	if httpsEnabled {
+	if cfg.HTTP.HTTPSEnabled() {
 		r.Use(middlewares.HSTS())
 	}
 
@@ -56,7 +86,15 @@ func SetupRoutes(svc *Services, hub *ws.WebsocketHub, httpsEnabled bool) http.Ha
 	if os.Getenv("SYFTBOX_REDIRECT_WWW") == "1" {
 		r.GET("/", IndexRedirectHandler)
 	} else {
-		r.GET("/", IndexHandler)
+		r.GET("/", func(c *gin.Context) {
+			// Check if this is a subdomain request
+			if isSubdomain, _ := c.Get(middlewares.IsSubdomainRequestKey); isSubdomain == true {
+				// Serve the explorer for subdomain root
+				explorerH.Handler(c)
+				return
+			}
+			IndexHandler(c)
+		})
 	}
 	r.GET("/healthz", HealthHandler)
 	r.GET("/install.sh", install.ServeSH)
@@ -108,6 +146,14 @@ func SetupRoutes(svc *Services, hub *ws.WebsocketHub, httpsEnabled bool) http.Ha
 	}
 
 	r.NoRoute(func(c *gin.Context) {
+		// Check if this is a subdomain request that got rewritten
+		if isSubdomain, _ := c.Get(middlewares.IsSubdomainRequestKey); isSubdomain == true {
+			// The path was already rewritten by middleware, serve it with explorer
+			explorerH.Handler(c)
+			return
+		}
+		
+		// Not a subdomain request, return 404
 		c.JSON(http.StatusNotFound, api.SyftAPIError{
 			Code:    api.CodeInvalidRequest,
 			Message: "not found",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,7 +52,7 @@ func New(config *Config) (*Server, error) {
 	}
 
 	hub := ws.NewHub()
-	httpHandler := SetupRoutes(services, hub, config.HTTP.HTTPSEnabled())
+	httpHandler := SetupRoutes(config, services, hub)
 
 	return &Server{
 		config: config,

--- a/internal/server/services.go
+++ b/internal/server/services.go
@@ -30,7 +30,10 @@ func NewServices(config *Config, db *sqlx.DB) (*Services, error) {
 
 	aclSvc := acl.NewACLService()
 
-	datasiteSvc := datasite.NewDatasiteService(blobSvc, aclSvc)
+	datasiteSvc := datasite.NewDatasiteService(blobSvc, aclSvc, config.HTTP.Domain)
+
+	// Set up blob change callback for dynamic vanity domain reloading
+	blobSvc.SetOnBlobChangeCallback(datasiteSvc.HandleBlobChange)
 
 	authSvc := auth.NewAuthService(&config.Auth, emailSvc)
 

--- a/internal/server/subdomain_routing_test.go
+++ b/internal/server/subdomain_routing_test.go
@@ -1,0 +1,722 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmined/syftbox/internal/server/middlewares"
+)
+
+func TestSubdomainPathRewriting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		originalPath string
+		email        string
+		vanityPath   string
+		expectedPath string
+	}{
+		{
+			name:         "Root path",
+			originalPath: "/",
+			email:        "alice@example.com",
+			vanityPath:   "/public",
+			expectedPath: "/datasites/alice@example.com/public/",
+		},
+		{
+			name:         "File path",
+			originalPath: "/index.html",
+			email:        "alice@example.com",
+			vanityPath:   "/public",
+			expectedPath: "/datasites/alice@example.com/public/index.html",
+		},
+		{
+			name:         "Nested path",
+			originalPath: "/docs/readme.md",
+			email:        "alice@example.com",
+			vanityPath:   "/public",
+			expectedPath: "/datasites/alice@example.com/public/docs/readme.md",
+		},
+		{
+			name:         "API path not rewritten",
+			originalPath: "/api/v1/status",
+			email:        "alice@example.com",
+			vanityPath:   "/public",
+			expectedPath: "/api/v1/status",
+		},
+		{
+			name:         "Vanity domain with custom path",
+			originalPath: "/post.html",
+			email:        "alice@example.com",
+			vanityPath:   "/blog",
+			expectedPath: "/datasites/alice@example.com/blog/post.html",
+		},
+		{
+			name:         "Vanity domain pointing to root",
+			originalPath: "/about.html",
+			email:        "alice@example.com",
+			vanityPath:   "/",
+			expectedPath: "/datasites/alice@example.com/about.html",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			
+			// Create subdomain middleware config
+			config := middlewares.SubdomainConfig{
+				MainDomain: "syftbox.net",
+				GetVanityDomainFunc: func(domain string) (string, string, bool) {
+					return tt.email, tt.vanityPath, true
+				},
+			}
+			
+			router.Use(middlewares.SubdomainMiddleware(config))
+			
+			// Test handler to capture the rewritten path
+			router.GET("/*path", func(c *gin.Context) {
+				actualPath := c.Request.URL.Path
+				assert.Equal(t, tt.expectedPath, actualPath)
+				c.Status(http.StatusOK)
+			})
+
+			// Create request with subdomain
+			req := httptest.NewRequest("GET", tt.originalPath, nil)
+			req.Host = "abc123.syftbox.net"
+			
+			// Perform request
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			
+			require.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}
+
+func TestSubdomainSecurityHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	
+	router := gin.New()
+	
+	// Create subdomain middleware config
+	config := middlewares.SubdomainConfig{
+		MainDomain: "syftbox.net",
+		GetVanityDomainFunc: func(domain string) (string, string, bool) {
+			if domain == "abc123.syftbox.net" {
+				return "alice@example.com", "/public", true
+			}
+			return "", "", false
+		},
+	}
+	
+	router.Use(middlewares.SubdomainMiddleware(config))
+	router.Use(middlewares.CORS())
+	router.Use(middlewares.SetSubdomainSecurityHeaders)
+	
+	// Test handler
+	router.GET("/*path", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	// Test subdomain request
+	req := httptest.NewRequest("GET", "/test.html", nil)
+	req.Host = "abc123.syftbox.net"
+	req.Header.Set("Origin", "https://abc123.syftbox.net")
+	
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	
+	// Check security headers
+	assert.Equal(t, "https://abc123.syftbox.net", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "true", w.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, "SAMEORIGIN", w.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "1; mode=block", w.Header().Get("X-XSS-Protection"))
+	assert.Equal(t, "same-origin", w.Header().Get("Referrer-Policy"))
+	assert.NotEmpty(t, w.Header().Get("Content-Security-Policy"))
+	
+	// Test main domain request (no subdomain)
+	req2 := httptest.NewRequest("GET", "/test.html", nil)
+	req2.Host = "syftbox.net"
+	
+	w2 := httptest.NewRecorder()
+	router.ServeHTTP(w2, req2)
+	
+	// Should not have subdomain-specific headers
+	assert.Empty(t, w2.Header().Get("X-Frame-Options"))
+	assert.Empty(t, w2.Header().Get("X-XSS-Protection"))
+	assert.Empty(t, w2.Header().Get("Referrer-Policy"))
+}
+
+func TestEndToEndSubdomainRouting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	
+	tests := []struct {
+		name               string
+		host               string
+		path               string
+		vanityDomains      map[string]struct{ email, path string }
+		expectedStatusCode int
+		expectedContent    string
+		checkHeaders       bool
+	}{
+		{
+			name: "Hash subdomain serves file",
+			host: "ff8d9819fc0e12bf.syftbox.net",
+			path: "/test.txt",
+			vanityDomains: map[string]struct{ email, path string }{
+				"ff8d9819fc0e12bf.syftbox.net": {"alice@example.com", "/public"},
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedContent:    "Test content for alice",
+			checkHeaders:       true,
+		},
+		{
+			name: "Vanity domain serves file",
+			host: "alice.blog",
+			path: "/post.html",
+			vanityDomains: map[string]struct{ email, path string }{
+				"alice.blog": {"alice@example.com", "/blog"},
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedContent:    "Blog post content",
+			checkHeaders:       true,
+		},
+		{
+			name: "Unknown subdomain returns 404",
+			host: "unknown.syftbox.net",
+			path: "/test.txt",
+			vanityDomains: map[string]struct{ email, path string }{},
+			expectedStatusCode: http.StatusNotFound,
+			checkHeaders:       false,
+		},
+		{
+			name: "Main domain serves normally",
+			host: "syftbox.net",
+			path: "/api/health",
+			vanityDomains: map[string]struct{ email, path string }{},
+			expectedStatusCode: http.StatusOK,
+			expectedContent:    "healthy",
+			checkHeaders:       false,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			
+			// Configure subdomain middleware
+			config := middlewares.SubdomainConfig{
+				MainDomain: "syftbox.net",
+				GetVanityDomainFunc: func(domain string) (string, string, bool) {
+					if cfg, exists := tt.vanityDomains[domain]; exists {
+						return cfg.email, cfg.path, true
+					}
+					return "", "", false
+				},
+			}
+			
+			router.Use(middlewares.SubdomainMiddleware(config))
+			router.Use(middlewares.CORS())
+			router.Use(middlewares.SetSubdomainSecurityHeaders)
+			
+			// Debug middleware to see what's happening
+			router.Use(func(c *gin.Context) {
+				fmt.Printf("DEBUG: Request path: %s, Host: %s\n", c.Request.URL.Path, c.Request.Host)
+				c.Next()
+			})
+			
+			// Catch all handler for rewritten paths
+			router.NoRoute(func(c *gin.Context) {
+				path := c.Request.URL.Path
+				fmt.Printf("DEBUG: NoRoute handler received path: %s\n", path)
+				
+				// Route based on the exact rewritten path
+				switch path {
+				case "/datasites/alice@example.com/public/test.txt":
+					c.String(http.StatusOK, "Test content for alice")
+				case "/datasites/alice@example.com/blog/post.html":
+					c.String(http.StatusOK, "Blog post content")
+				default:
+					fmt.Printf("DEBUG: No match for path: %s\n", path)
+					c.String(http.StatusNotFound, "404 page not found")
+				}
+			})
+			
+			router.GET("/api/health", func(c *gin.Context) {
+				c.String(http.StatusOK, "healthy")
+			})
+			
+			// Create request
+			req := httptest.NewRequest("GET", tt.path, nil)
+			req.Host = tt.host
+			
+			// Perform request
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			
+			// Check status code
+			assert.Equal(t, tt.expectedStatusCode, w.Code)
+			
+			// Check content if expected
+			if tt.expectedContent != "" {
+				assert.Equal(t, tt.expectedContent, w.Body.String())
+			}
+			
+			// Check security headers for subdomain requests
+			if tt.checkHeaders && w.Code == http.StatusOK {
+				assert.NotEmpty(t, w.Header().Get("X-Frame-Options"))
+				assert.NotEmpty(t, w.Header().Get("X-Content-Type-Options"))
+			}
+		})
+	}
+}
+
+func TestIndexHTMLAutoServing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	
+	router := gin.New()
+	
+	// Configure subdomain middleware
+	config := middlewares.SubdomainConfig{
+		MainDomain: "syftbox.net",
+		GetVanityDomainFunc: func(domain string) (string, string, bool) {
+			if domain == "ff8d9819fc0e12bf.syftbox.net" {
+				return "alice@example.com", "/public", true
+			}
+			return "", "", false
+		},
+	}
+	
+	router.Use(middlewares.SubdomainMiddleware(config))
+	
+	// Debug middleware
+	router.Use(func(c *gin.Context) {
+		fmt.Printf("DEBUG Index: Request path: %s, Host: %s\n", c.Request.URL.Path, c.Request.Host)
+		c.Next()
+	})
+	
+	// NoRoute handler to catch rewritten paths
+	router.NoRoute(func(c *gin.Context) {
+		path := c.Request.URL.Path
+		fmt.Printf("DEBUG Index NoRoute: %s\n", path)
+		
+		// Extract the path after /datasites/alice@example.com
+		if strings.HasPrefix(path, "/datasites/alice@example.com") {
+			relativePath := strings.TrimPrefix(path, "/datasites/alice@example.com")
+			
+			// If path ends with /, serve index.html
+			if strings.HasSuffix(relativePath, "/") {
+				c.String(http.StatusOK, fmt.Sprintf("index.html content for %s", relativePath))
+			} else if strings.HasSuffix(relativePath, "/index.html") {
+				// Extract directory path for index.html
+				dirPath := strings.TrimSuffix(relativePath, "index.html")
+				c.String(http.StatusOK, fmt.Sprintf("index.html content for %s", dirPath))
+			} else {
+				// Serve regular file
+				c.String(http.StatusOK, fmt.Sprintf("file content for %s", relativePath))
+			}
+		} else {
+			c.String(http.StatusNotFound, "404 page not found")
+		}
+	})
+	
+	tests := []struct {
+		name            string
+		path            string
+		expectedContent string
+	}{
+		{
+			name:            "Root directory serves index.html",
+			path:            "/",
+			expectedContent: "index.html content for /public/",
+		},
+		{
+			name:            "Subdirectory serves index.html",
+			path:            "/docs/",
+			expectedContent: "index.html content for /public/docs/",
+		},
+		{
+			name:            "Direct index.html request",
+			path:            "/index.html",
+			expectedContent: "index.html content for /public/",
+		},
+		{
+			name:            "Regular file request",
+			path:            "/readme.md",
+			expectedContent: "file content for /public/readme.md",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			req.Host = "ff8d9819fc0e12bf.syftbox.net"
+			
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, tt.expectedContent, w.Body.String())
+		})
+	}
+}
+
+func TestRelativeLinkGeneration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	
+	router := gin.New()
+	
+	// Configure subdomain middleware
+	config := middlewares.SubdomainConfig{
+		MainDomain: "syftbox.net",
+		GetVanityDomainFunc: func(domain string) (string, string, bool) {
+			if domain == "alice.blog" {
+				return "alice@example.com", "/blog", true
+			}
+			return "", "", false
+		},
+	}
+	
+	router.Use(middlewares.SubdomainMiddleware(config))
+	
+	// NoRoute handler for rewritten paths
+	router.NoRoute(func(c *gin.Context) {
+		path := c.Request.URL.Path
+		
+		// Check if it's a datasite path
+		if strings.HasPrefix(path, "/datasites/alice@example.com/blog/") {
+			// Generate a simple directory listing with relative links
+			html := `<html><body><ul>`
+			html += `<li><a href="post1.html">Post 1</a></li>`
+			html += `<li><a href="post2.html">Post 2</a></li>`
+			html += `<li><a href="images/">Images Directory</a></li>`
+			html += `<li><a href="../">Parent Directory</a></li>`
+			html += `</ul></body></html>`
+			
+			c.Header("Content-Type", "text/html")
+			c.String(http.StatusOK, html)
+		} else {
+			c.String(http.StatusNotFound, "404 page not found")
+		}
+	})
+	
+	// Request directory listing
+	req := httptest.NewRequest("GET", "/posts/", nil)
+	req.Host = "alice.blog"
+	
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `href="post1.html"`)
+	assert.Contains(t, w.Body.String(), `href="post2.html"`)
+	assert.Contains(t, w.Body.String(), `href="images/"`)
+	assert.Contains(t, w.Body.String(), `href="../"`)
+}
+
+func TestACLEnforcementForSubdomains(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	
+	// Mock ACL checker
+	aclChecker := func(email, path, requester string) bool {
+		// Public files are accessible to everyone
+		if strings.Contains(path, "/public/") {
+			return true
+		}
+		// Alice can access her own files
+		if email == "alice@example.com" && requester == "alice@example.com" {
+			return true
+		}
+		// Bob cannot access Alice's private files
+		if email == "alice@example.com" && requester == "bob@example.com" {
+			return false
+		}
+		return false
+	}
+	
+	router := gin.New()
+	
+	// Configure subdomain middleware
+	config := middlewares.SubdomainConfig{
+		MainDomain: "syftbox.net",
+		GetVanityDomainFunc: func(domain string) (string, string, bool) {
+			if domain == "ff8d9819fc0e12bf.syftbox.net" {
+				return "alice@example.com", "/public", true
+			}
+			if domain == "alice.private" {
+				return "alice@example.com", "/private", true
+			}
+			return "", "", false
+		},
+	}
+	
+	router.Use(middlewares.SubdomainMiddleware(config))
+	
+	// Mock ACL middleware
+	router.Use(func(c *gin.Context) {
+		// Extract subdomain email
+		email, _ := middlewares.GetSubdomainEmail(c)
+		path := c.Request.URL.Path
+		
+		// Get requester from header (in real app, from JWT)
+		requester := c.GetHeader("X-Requester")
+		
+		if email != "" && !aclChecker(email, path, requester) {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+		
+		c.Next()
+	})
+	
+	// NoRoute handler for rewritten paths (Gin can't handle @ in route parameters)
+	router.NoRoute(func(c *gin.Context) {
+		path := c.Request.URL.Path
+		
+		// Check if it's a datasite path that should return content
+		if strings.HasPrefix(path, "/datasites/alice@example.com/") {
+			c.String(http.StatusOK, "File content")
+		} else {
+			c.String(http.StatusNotFound, "404 page not found")
+		}
+	})
+	
+	tests := []struct {
+		name               string
+		host               string
+		path               string
+		requester          string
+		expectedStatusCode int
+	}{
+		{
+			name:               "Alice accesses her public files",
+			host:               "ff8d9819fc0e12bf.syftbox.net",
+			path:               "/test.txt",
+			requester:          "alice@example.com",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Bob accesses Alice's public files",
+			host:               "ff8d9819fc0e12bf.syftbox.net",
+			path:               "/test.txt",
+			requester:          "bob@example.com",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Alice accesses her private files",
+			host:               "alice.private",
+			path:               "/secret.txt",
+			requester:          "alice@example.com",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:               "Bob cannot access Alice's private files",
+			host:               "alice.private",
+			path:               "/secret.txt",
+			requester:          "bob@example.com",
+			expectedStatusCode: http.StatusForbidden,
+		},
+		{
+			name:               "Anonymous access to public files",
+			host:               "ff8d9819fc0e12bf.syftbox.net",
+			path:               "/test.txt",
+			requester:          "",
+			expectedStatusCode: http.StatusOK,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.path, nil)
+			req.Host = tt.host
+			if tt.requester != "" {
+				req.Header.Set("X-Requester", tt.requester)
+			}
+			
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			
+			assert.Equal(t, tt.expectedStatusCode, w.Code)
+		})
+	}
+}
+
+func TestVanityDomainPathMapping(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	
+	// Test different vanity domain configurations
+	vanityConfigs := map[string]struct{ email, path string }{
+		"alice.blog":         {"alice@example.com", "/blog"},
+		"alice.portfolio":    {"alice@example.com", "/portfolio"},
+		"projects.alice.dev": {"alice@example.com", "/projects/2024"},
+		"alice.site":         {"alice@example.com", "/"}, // Points to root
+	}
+	
+	router := gin.New()
+	
+	// Configure subdomain middleware
+	config := middlewares.SubdomainConfig{
+		MainDomain: "syftbox.net",
+		GetVanityDomainFunc: func(domain string) (string, string, bool) {
+			if cfg, exists := vanityConfigs[domain]; exists {
+				return cfg.email, cfg.path, true
+			}
+			return "", "", false
+		},
+	}
+	
+	router.Use(middlewares.SubdomainMiddleware(config))
+	
+	// NoRoute handler that echoes the path (Gin can't handle @ in route parameters)
+	router.NoRoute(func(c *gin.Context) {
+		path := c.Request.URL.Path
+		
+		// For vanity domain path mapping test, echo back the rewritten path
+		if strings.HasPrefix(path, "/datasites/alice@example.com/") {
+			c.String(http.StatusOK, path)
+		} else {
+			c.String(http.StatusNotFound, "404 page not found")
+		}
+	})
+	
+	tests := []struct {
+		name         string
+		host         string
+		requestPath  string
+		expectedPath string
+	}{
+		{
+			name:         "Blog domain root",
+			host:         "alice.blog",
+			requestPath:  "/",
+			expectedPath: "/datasites/alice@example.com/blog/",
+		},
+		{
+			name:         "Blog domain with file",
+			host:         "alice.blog",
+			requestPath:  "/post1.html",
+			expectedPath: "/datasites/alice@example.com/blog/post1.html",
+		},
+		{
+			name:         "Portfolio domain",
+			host:         "alice.portfolio",
+			requestPath:  "/project1/index.html",
+			expectedPath: "/datasites/alice@example.com/portfolio/project1/index.html",
+		},
+		{
+			name:         "Nested vanity path",
+			host:         "projects.alice.dev",
+			requestPath:  "/demo/app.js",
+			expectedPath: "/datasites/alice@example.com/projects/2024/demo/app.js",
+		},
+		{
+			name:         "Root vanity domain",
+			host:         "alice.site",
+			requestPath:  "/about.html",
+			expectedPath: "/datasites/alice@example.com/about.html",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.requestPath, nil)
+			req.Host = tt.host
+			
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, tt.expectedPath, w.Body.String())
+		})
+	}
+}
+
+func TestHashAndVanityDomainCoexistence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	
+	router := gin.New()
+	
+	aliceHash := middlewares.EmailToSubdomainHash("alice@example.com")
+	
+	// Configure both hash and vanity domains for same user
+	vanityConfigs := map[string]struct{ email, path string }{
+		aliceHash + ".syftbox.net": {"alice@example.com", "/public"},
+		"alice.blog":               {"alice@example.com", "/blog"},
+		"alice.dev":                {"alice@example.com", "/dev"},
+	}
+	
+	config := middlewares.SubdomainConfig{
+		MainDomain: "syftbox.net",
+		GetVanityDomainFunc: func(domain string) (string, string, bool) {
+			if cfg, exists := vanityConfigs[domain]; exists {
+				return cfg.email, cfg.path, true
+			}
+			return "", "", false
+		},
+	}
+	
+	router.Use(middlewares.SubdomainMiddleware(config))
+	
+	// NoRoute handler that returns the domain type (Gin can't handle @ in route parameters)
+	router.NoRoute(func(c *gin.Context) {
+		path := c.Request.URL.Path
+		
+		// Check if it's a datasite path
+		if strings.HasPrefix(path, "/datasites/alice@example.com/") {
+			isVanity, _ := c.Get("is_vanity_domain")
+			vanityDomain, _ := c.Get("vanity_domain")
+			
+			response := fmt.Sprintf("Path: %s, IsVanity: %v, Domain: %v", 
+				path, isVanity, vanityDomain)
+			c.String(http.StatusOK, response)
+		} else {
+			c.String(http.StatusNotFound, "404 page not found")
+		}
+	})
+	
+	tests := []struct {
+		name           string
+		host           string
+		expectedDomain string
+	}{
+		{
+			name:           "Hash subdomain",
+			host:           aliceHash + ".syftbox.net",
+			expectedDomain: aliceHash + ".syftbox.net",
+		},
+		{
+			name:           "Blog vanity domain",
+			host:           "alice.blog",
+			expectedDomain: "alice.blog",
+		},
+		{
+			name:           "Dev vanity domain",
+			host:           "alice.dev",
+			expectedDomain: "alice.dev",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test.html", nil)
+			req.Host = tt.host
+			
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, w.Body.String(), "IsVanity: true")
+			assert.Contains(t, w.Body.String(), fmt.Sprintf("Domain: %s", tt.expectedDomain))
+		})
+	}
+}

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -1,0 +1,76 @@
+package utils
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestResolvePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantError bool
+	}{
+		{
+			name:      "empty path",
+			input:     "",
+			wantError: true,
+		},
+		{
+			name:      "relative path",
+			input:     "./test",
+			wantError: false,
+		},
+		{
+			name:      "absolute path",
+			input:     "/tmp/test",
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ResolvePath(tt.input)
+			if (err != nil) != tt.wantError {
+				t.Errorf("ResolvePath(%q) error = %v, wantError %v", tt.input, err, tt.wantError)
+			}
+			if !tt.wantError && result == "" {
+				t.Errorf("ResolvePath(%q) returned empty string", tt.input)
+			}
+		})
+	}
+}
+
+func TestWindowsPathHandling(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Skipping Windows-specific tests on non-Windows platform")
+	}
+
+	// Test that Windows paths are handled correctly
+	tests := []struct {
+		name  string
+		path  string
+		isDir bool
+	}{
+		{
+			name:  "Windows path with backslashes",
+			path:  `C:\Windows\System32`,
+			isDir: true,
+		},
+		{
+			name:  "Windows path with forward slashes",
+			path:  "C:/Windows/System32",
+			isDir: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Just test that the path operations don't panic
+			_ = filepath.Clean(tt.path)
+			_ = filepath.Dir(tt.path)
+			_ = filepath.Base(tt.path)
+		})
+	}
+}

--- a/justfile
+++ b/justfile
@@ -237,5 +237,33 @@ setup-toolchain:
     go install filippo.io/mkcert@latest
 
 [group('utils')]
+email-hash email domain="":
+    #!/bin/bash
+    set -eou pipefail
+    
+    if [ -z "{{ email }}" ]; then
+        echo "Usage: just email-hash <email> [domain]"
+        echo "Examples:"
+        echo "  just email-hash alice@example.com"
+        echo "  just email-hash alice@example.com syftbox.com"
+        exit 1
+    fi
+    
+    # Generate the hash (first 16 chars of sha256)
+    hash=$(echo -n "{{ email }}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]' | shasum -a 256 | cut -c1-16)
+    
+    echo "Email: {{ email }}"
+    echo "Hash: $hash"
+    echo ""
+    
+    if [ -z "{{ domain }}" ]; then
+        # No domain provided, use local development URL
+        echo "URL: http://$hash.syftbox.local:8080/"
+    else
+        # Domain provided, use HTTPS
+        echo "URL: https://$hash.{{ domain }}/"
+    fi
+
+[group('utils')]
 clean:
     rm -rf .data .out releases certs cover.out


### PR DESCRIPTION
- Add subdomain middleware to route hash-based subdomains (e.g., ff8d9819fc0e12bf.syftbox.local)
- Implement automatic subdomain mapping when datasites are created
- Support vanity domains via settings.yaml configuration
- Add debug endpoints for subdomain troubleshooting
- Add `just email-hash` command to generate subdomain URLs from emails
- Added docs on how it all works and how to test it manually
- Added unit tests