### PR TITLE
Increasing coverage of ACL / Permissions

### DIFF
--- a/internal/aclspec/access_test.go
+++ b/internal/aclspec/access_test.go
@@ -1,0 +1,261 @@
+package aclspec
+
+import (
+	"testing"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewAccess(t *testing.T) {
+	// Test creating Access with different user email combinations
+	// This tests the core constructor and validates that sets are properly initialized
+	admin := []string{"admin@example.com", "owner@company.org"}
+	write := []string{"writer1@openmined.org", "writer2@research.edu", "collab@university.ac.uk"}
+	read := []string{"reader@public.org"}
+
+	access := NewAccess(admin, write, read)
+
+	// Verify all sets are properly initialized and contain expected user emails
+	assert.True(t, access.Admin.Contains("admin@example.com"))
+	assert.True(t, access.Admin.Contains("owner@company.org"))
+	assert.Equal(t, 2, access.Admin.Cardinality())
+
+	assert.True(t, access.Write.Contains("writer1@openmined.org"))
+	assert.True(t, access.Write.Contains("writer2@research.edu"))
+	assert.True(t, access.Write.Contains("collab@university.ac.uk"))
+	assert.Equal(t, 3, access.Write.Cardinality())
+
+	assert.True(t, access.Read.Contains("reader@public.org"))
+	assert.Equal(t, 1, access.Read.Cardinality())
+}
+
+func TestNewAccessWithEmptyLists(t *testing.T) {
+	// Test edge case of creating Access with empty lists
+	// This ensures the constructor handles empty inputs gracefully
+	access := NewAccess([]string{}, []string{}, []string{})
+
+	assert.Equal(t, 0, access.Admin.Cardinality())
+	assert.Equal(t, 0, access.Write.Cardinality())
+	assert.Equal(t, 0, access.Read.Cardinality())
+}
+
+func TestPrivateAccess(t *testing.T) {
+	// Test that PrivateAccess creates an Access object with no permissions
+	// This is a critical security test - private should mean NO access for anyone
+	access := PrivateAccess()
+
+	assert.Equal(t, 0, access.Admin.Cardinality(), "Private access should have no admin users")
+	assert.Equal(t, 0, access.Write.Cardinality(), "Private access should have no write users")
+	assert.Equal(t, 0, access.Read.Cardinality(), "Private access should have no read users")
+}
+
+func TestPublicReadAccess(t *testing.T) {
+	// Test that PublicReadAccess grants read access to everyone but nothing else
+	// This validates the most common public sharing scenario
+	access := PublicReadAccess()
+
+	assert.Equal(t, 0, access.Admin.Cardinality(), "Public read should have no admin users")
+	assert.Equal(t, 0, access.Write.Cardinality(), "Public read should have no write users")
+	assert.Equal(t, 1, access.Read.Cardinality(), "Public read should have exactly one read entry")
+	assert.True(t, access.Read.Contains(Everyone), "Public read should grant read access to everyone")
+}
+
+func TestPublicReadWriteAccess(t *testing.T) {
+	// Test that PublicReadWriteAccess grants write (and implicitly read) access to everyone
+	// This tests the dangerous but sometimes necessary full public access
+	access := PublicReadWriteAccess()
+
+	assert.Equal(t, 0, access.Admin.Cardinality(), "Public read-write should have no admin users")
+	assert.Equal(t, 1, access.Write.Cardinality(), "Public read-write should have exactly one write entry")
+	assert.True(t, access.Write.Contains(Everyone), "Public read-write should grant write access to everyone")
+	assert.Equal(t, 0, access.Read.Cardinality(), "Public read-write should not set read (write implies read)")
+}
+
+func TestSharedReadAccess(t *testing.T) {
+	// Test creating shared read access for specific user emails
+	// This validates the common scenario of sharing read access with specific collaborators
+	users := []string{"alice@research.org", "bob@university.edu", "charlie@company.com"}
+	access := SharedReadAccess(users...)
+
+	assert.Equal(t, 0, access.Admin.Cardinality(), "Shared read should have no admin users")
+	assert.Equal(t, 0, access.Write.Cardinality(), "Shared read should have no write users")
+	assert.Equal(t, 3, access.Read.Cardinality(), "Shared read should have exactly the specified users")
+	
+	for _, user := range users {
+		assert.True(t, access.Read.Contains(user), "Shared read should contain user %s", user)
+	}
+}
+
+func TestSharedReadWriteAccess(t *testing.T) {
+	// Test creating shared read-write access for specific user emails
+	// This validates collaborative scenarios where specific users need write access
+	users := []string{"maintainer1@openmined.org", "maintainer2@research.edu"}
+	access := SharedReadWriteAccess(users...)
+
+	assert.Equal(t, 0, access.Admin.Cardinality(), "Shared read-write should have no admin users")
+	assert.Equal(t, 2, access.Write.Cardinality(), "Shared read-write should have exactly the specified users")
+	assert.Equal(t, 0, access.Read.Cardinality(), "Shared read-write should not set read (write implies read)")
+	
+	for _, user := range users {
+		assert.True(t, access.Write.Contains(user), "Shared read-write should contain user %s", user)
+	}
+}
+
+func TestAccessUnmarshalYAML(t *testing.T) {
+	// Test unmarshaling Access from YAML format
+	// This is critical for loading syft.pub.yaml files from disk
+	yamlData := `
+admin: ["admin@example.com", "owner@company.org"]
+read: ["reader1@public.org", "reader2@university.edu", "reader3@research.net"]
+write: ["writer@openmined.org"]
+`
+
+	var access Access
+	err := yaml.Unmarshal([]byte(yamlData), &access)
+	require.NoError(t, err, "YAML unmarshaling should succeed")
+
+	// Verify that all user emails were properly loaded into their respective sets
+	assert.Equal(t, 2, access.Admin.Cardinality())
+	assert.True(t, access.Admin.Contains("admin@example.com"))
+	assert.True(t, access.Admin.Contains("owner@company.org"))
+
+	assert.Equal(t, 3, access.Read.Cardinality())
+	assert.True(t, access.Read.Contains("reader1@public.org"))
+	assert.True(t, access.Read.Contains("reader2@university.edu"))
+	assert.True(t, access.Read.Contains("reader3@research.net"))
+
+	assert.Equal(t, 1, access.Write.Cardinality())
+	assert.True(t, access.Write.Contains("writer@openmined.org"))
+}
+
+func TestAccessUnmarshalYAMLWithMissingSections(t *testing.T) {
+	// Test unmarshaling when some access sections are missing
+	// This ensures the system handles partial configurations gracefully
+	yamlData := `
+read: ["reader@example.com"]
+# write and admin sections intentionally missing
+`
+
+	var access Access
+	err := yaml.Unmarshal([]byte(yamlData), &access)
+	require.NoError(t, err, "YAML unmarshaling should succeed even with missing sections")
+
+	// Missing sections should result in empty sets, not nil
+	assert.Equal(t, 0, access.Admin.Cardinality(), "Missing admin section should result in empty set")
+	assert.Equal(t, 0, access.Write.Cardinality(), "Missing write section should result in empty set")
+	assert.Equal(t, 1, access.Read.Cardinality(), "Read section should be properly loaded")
+	assert.True(t, access.Read.Contains("reader@example.com"))
+}
+
+func TestAccessUnmarshalYAMLWithEmptyLists(t *testing.T) {
+	// Test unmarshaling with explicitly empty lists
+	// This ensures empty lists in YAML are handled correctly
+	yamlData := `
+admin: []
+read: []
+write: ["writer@company.com"]
+`
+
+	var access Access
+	err := yaml.Unmarshal([]byte(yamlData), &access)
+	require.NoError(t, err, "YAML unmarshaling should succeed with empty lists")
+
+	assert.Equal(t, 0, access.Admin.Cardinality())
+	assert.Equal(t, 0, access.Read.Cardinality())
+	assert.Equal(t, 1, access.Write.Cardinality())
+	assert.True(t, access.Write.Contains("writer@company.com"))
+}
+
+func TestAccessUnmarshalYAMLInvalidFormat(t *testing.T) {
+	// Test that invalid YAML format is properly rejected
+	// This ensures the system fails safely on malformed input
+	yamlData := `
+admin: "should_be_a_list_not_string"
+`
+
+	var access Access
+	err := yaml.Unmarshal([]byte(yamlData), &access)
+	assert.Error(t, err, "Invalid YAML format should be rejected")
+}
+
+func TestAccessMarshalYAML(t *testing.T) {
+	// Test marshaling Access to YAML format
+	// This is critical for saving syft.pub.yaml files to disk
+	access := NewAccess(
+		[]string{"admin@example.com", "owner@company.org"},
+		[]string{"writer@openmined.org"},
+		[]string{"reader1@public.org", "reader2@university.edu"},
+	)
+
+	data, err := yaml.Marshal(access)
+	require.NoError(t, err, "YAML marshaling should succeed")
+
+	// Unmarshal back to verify the round-trip works correctly
+	var unmarshaled Access
+	err = yaml.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err, "Round-trip unmarshaling should succeed")
+
+	// Verify all data survived the round-trip
+	assert.Equal(t, access.Admin.Cardinality(), unmarshaled.Admin.Cardinality())
+	assert.Equal(t, access.Write.Cardinality(), unmarshaled.Write.Cardinality())
+	assert.Equal(t, access.Read.Cardinality(), unmarshaled.Read.Cardinality())
+
+	// Check that all user emails are preserved
+	for _, user := range access.Admin.ToSlice() {
+		assert.True(t, unmarshaled.Admin.Contains(user))
+	}
+	for _, user := range access.Write.ToSlice() {
+		assert.True(t, unmarshaled.Write.Contains(user))
+	}
+	for _, user := range access.Read.ToSlice() {
+		assert.True(t, unmarshaled.Read.Contains(user))
+	}
+}
+
+func TestAccessMarshalYAMLWithNilSets(t *testing.T) {
+	// Test marshaling when some sets are nil
+	// This tests the defensive programming in MarshalYAML
+	access := Access{
+		Admin: mapset.NewSet("admin@example.com"),
+		Write: nil, // Intentionally nil
+		Read:  mapset.NewSet("reader@public.org"),
+	}
+
+	data, err := yaml.Marshal(access)
+	require.NoError(t, err, "YAML marshaling should handle nil sets gracefully")
+
+	// Verify the marshaled data is valid YAML
+	var result map[string][]string
+	err = yaml.Unmarshal(data, &result)
+	require.NoError(t, err, "Marshaled YAML should be valid")
+
+	// Nil sets should not appear in the output
+	assert.Contains(t, result, "admin")
+	assert.Contains(t, result, "read")
+	assert.NotContains(t, result, "write", "Nil sets should not appear in marshaled YAML")
+}
+
+func TestAccessMarshalYAMLWithEmptySets(t *testing.T) {
+	// Test marshaling when sets are empty but not nil
+	// This verifies that empty sets are handled consistently
+	access := NewAccess(
+		[]string{}, // Empty admin
+		[]string{}, // Empty write
+		[]string{"reader@example.com"}, // Non-empty read
+	)
+
+	data, err := yaml.Marshal(access)
+	require.NoError(t, err, "YAML marshaling should handle empty sets")
+
+	var result map[string][]string
+	err = yaml.Unmarshal(data, &result)
+	require.NoError(t, err, "Marshaled YAML should be valid")
+
+	// Empty sets should appear as empty arrays in YAML
+	assert.Equal(t, []string{}, result["admin"])
+	assert.Equal(t, []string{}, result["write"])
+	assert.Contains(t, result["read"], "reader@example.com")
+}

--- a/internal/aclspec/aclspec.go
+++ b/internal/aclspec/aclspec.go
@@ -33,11 +33,18 @@ func WithoutACLPath(path string) string {
 }
 
 // Exists checks if the ACL file exists at the given path
+// For security reasons, symlinks are not allowed as ACL files
 func Exists(path string) bool {
 	aclPath := AsACLPath(path)
-	stat, err := os.Stat(aclPath)
+	stat, err := os.Lstat(aclPath) // Use Lstat to not follow symlinks
 	if os.IsNotExist(err) {
 		return false
 	}
+	
+	// Reject symlinks for security reasons
+	if stat.Mode()&os.ModeSymlink != 0 {
+		return false
+	}
+	
 	return stat.Size() > 0
 }

--- a/internal/aclspec/aclspec_test.go
+++ b/internal/aclspec/aclspec_test.go
@@ -1,0 +1,357 @@
+package aclspec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsACLFile(t *testing.T) {
+	// Test the core ACL file detection logic
+	// This is critical for the system to recognize permission files correctly
+	testCases := []struct {
+		path     string
+		expected bool
+		desc     string
+	}{
+		{
+			path:     "syft.pub.yaml",
+			expected: true,
+			desc:     "Direct ACL filename should be detected",
+		},
+		{
+			path:     "/path/to/syft.pub.yaml",
+			expected: true,
+			desc:     "ACL file with full path should be detected",
+		},
+		{
+			path:     "folder/subfolder/syft.pub.yaml",
+			expected: true,
+			desc:     "ACL file in nested path should be detected",
+		},
+		{
+			path:     "not_an_acl_file.yaml",
+			expected: false,
+			desc:     "Regular YAML file should not be detected as ACL",
+		},
+		{
+			path:     "syft.pub.yaml.backup",
+			expected: false,
+			desc:     "ACL filename with suffix should not be detected",
+		},
+		{
+			path:     "prefix_syft.pub.yaml",
+			expected: true,
+			desc:     "ACL filename with prefix should be detected (suffix match)",
+		},
+		{
+			path:     "",
+			expected: false,
+			desc:     "Empty path should not be detected as ACL",
+		},
+		{
+			path:     "syft.pub.yml",
+			expected: false,
+			desc:     "Wrong extension (.yml vs .yaml) should not be detected",
+		},
+		{
+			path:     "SYFT.PUB.YAML",
+			expected: false,
+			desc:     "Case-sensitive check - uppercase should not match",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := IsACLFile(tc.path)
+			assert.Equal(t, tc.expected, result, "Path: %s", tc.path)
+		})
+	}
+}
+
+func TestAsACLPath(t *testing.T) {
+	// Test converting directory paths to ACL file paths
+	// This ensures the system can correctly locate ACL files for directories
+	testCases := []struct {
+		input    string
+		expected string
+		desc     string
+	}{
+		{
+			input:    "/home/user",
+			expected: "/home/user/syft.pub.yaml",
+			desc:     "Directory path should get ACL filename appended",
+		},
+		{
+			input:    "/home/user/syft.pub.yaml",
+			expected: "/home/user/syft.pub.yaml",
+			desc:     "ACL file path should remain unchanged",
+		},
+		{
+			input:    "",
+			expected: "syft.pub.yaml",
+			desc:     "Empty path should result in just the ACL filename",
+		},
+		{
+			input:    "relative/path",
+			expected: "relative/path/syft.pub.yaml",
+			desc:     "Relative path should get ACL filename appended",
+		},
+		{
+			input:    "/",
+			expected: "/syft.pub.yaml",
+			desc:     "Root directory should get ACL filename appended",
+		},
+		{
+			input:    "folder/syft.pub.yaml",
+			expected: "folder/syft.pub.yaml",
+			desc:     "Path already ending with ACL filename should be unchanged",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := AsACLPath(tc.input)
+			assert.Equal(t, tc.expected, result, "Input: %s", tc.input)
+		})
+	}
+}
+
+func TestWithoutACLPath(t *testing.T) {
+	// Test removing ACL filename from paths
+	// This is used to get the directory path from an ACL file path
+	testCases := []struct {
+		input    string
+		expected string
+		desc     string
+	}{
+		{
+			input:    "/home/user/syft.pub.yaml",
+			expected: "/home/user/",
+			desc:     "ACL file path should have filename removed",
+		},
+		{
+			input:    "syft.pub.yaml",
+			expected: "",
+			desc:     "Bare ACL filename should result in empty string",
+		},
+		{
+			input:    "/home/user/other.yaml",
+			expected: "/home/user/other.yaml",
+			desc:     "Non-ACL file path should remain unchanged",
+		},
+		{
+			input:    "/home/user/",
+			expected: "/home/user/",
+			desc:     "Directory path without ACL filename should remain unchanged",
+		},
+		{
+			input:    "",
+			expected: "",
+			desc:     "Empty path should remain empty",
+		},
+		{
+			input:    "folder/subfolder/syft.pub.yaml",
+			expected: "folder/subfolder/",
+			desc:     "Nested ACL file path should have filename removed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := WithoutACLPath(tc.input)
+			assert.Equal(t, tc.expected, result, "Input: %s", tc.input)
+		})
+	}
+}
+
+func TestExists(t *testing.T) {
+	// Test ACL file existence detection
+	// This validates the system can correctly detect existing ACL files on disk
+	
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	
+	// Create a test ACL file with some content
+	aclFilePath := filepath.Join(tempDir, AclFileName)
+	err := os.WriteFile(aclFilePath, []byte("terminal: true\nrules: []"), 0644)
+	require.NoError(t, err, "Should be able to create test ACL file")
+	
+	// Test that existing non-empty ACL file is detected
+	assert.True(t, Exists(tempDir), "Should detect existing ACL file in directory")
+	assert.True(t, Exists(aclFilePath), "Should detect existing ACL file by direct path")
+	
+	// Create an empty ACL file
+	emptyAclDir := filepath.Join(tempDir, "empty")
+	err = os.Mkdir(emptyAclDir, 0755)
+	require.NoError(t, err, "Should be able to create test directory")
+	
+	emptyAclFile := filepath.Join(emptyAclDir, AclFileName)
+	err = os.WriteFile(emptyAclFile, []byte{}, 0644)
+	require.NoError(t, err, "Should be able to create empty ACL file")
+	
+	// Test that empty ACL file is not considered as existing
+	assert.False(t, Exists(emptyAclDir), "Empty ACL file should not be considered as existing")
+	
+	// Test that non-existent path returns false
+	nonExistentPath := filepath.Join(tempDir, "nonexistent")
+	assert.False(t, Exists(nonExistentPath), "Non-existent path should return false")
+	
+	// Test that directory without ACL file returns false
+	noAclDir := filepath.Join(tempDir, "no_acl")
+	err = os.Mkdir(noAclDir, 0755)
+	require.NoError(t, err, "Should be able to create test directory")
+	
+	assert.False(t, Exists(noAclDir), "Directory without ACL file should return false")
+}
+
+func TestExistsWithSymlinks(t *testing.T) {
+	// Test that symlinks are rejected for security reasons
+	// ACL files must be regular files, not symlinks
+	
+	tempDir := t.TempDir()
+	
+	// Create actual ACL file
+	realAclDir := filepath.Join(tempDir, "real")
+	err := os.Mkdir(realAclDir, 0755)
+	require.NoError(t, err)
+	
+	realAclFile := filepath.Join(realAclDir, AclFileName)
+	err = os.WriteFile(realAclFile, []byte("terminal: true"), 0644)
+	require.NoError(t, err)
+	
+	// Verify real ACL file is detected
+	assert.True(t, Exists(realAclDir), "Real ACL file should be detected")
+	
+	// Create symlink to the ACL file
+	symlinkDir := filepath.Join(tempDir, "symlink")
+	err = os.Mkdir(symlinkDir, 0755)
+	require.NoError(t, err)
+	
+	symlinkAclFile := filepath.Join(symlinkDir, AclFileName)
+	err = os.Symlink(realAclFile, symlinkAclFile)
+	require.NoError(t, err)
+	
+	// Test that symlinked ACL file is REJECTED for security reasons
+	assert.False(t, Exists(symlinkDir), "Symlinked ACL files should be rejected for security")
+	
+	// Test that LoadFromFile also rejects symlinks
+	_, err = LoadFromFile(symlinkDir)
+	assert.Error(t, err, "LoadFromFile should reject symlinked ACL files")
+	assert.Contains(t, err.Error(), "symlinks are not allowed", "Error should mention symlink restriction")
+	
+	// Create broken symlink
+	brokenDir := filepath.Join(tempDir, "broken")
+	err = os.Mkdir(brokenDir, 0755)
+	require.NoError(t, err)
+	
+	brokenSymlink := filepath.Join(brokenDir, AclFileName)
+	err = os.Symlink("/nonexistent/file", brokenSymlink)
+	require.NoError(t, err)
+	
+	// Test that broken symlink is also rejected
+	assert.False(t, Exists(brokenDir), "Broken symlinks should be rejected")
+	
+	// Test that LoadFromFile also rejects broken symlinks
+	_, err = LoadFromFile(brokenDir)
+	assert.Error(t, err, "LoadFromFile should reject broken symlinks")
+	assert.Contains(t, err.Error(), "symlinks are not allowed", "Error should mention symlink restriction")
+}
+
+func TestSymlinkSecurityComprehensive(t *testing.T) {
+	// Comprehensive test to ensure symlinks are rejected at all entry points
+	// This is critical for security - no ACL operation should follow symlinks
+	
+	tempDir := t.TempDir()
+	
+	// Create a legitimate ACL file
+	realAclFile := filepath.Join(tempDir, "real.yaml")
+	aclContent := `
+terminal: true
+rules:
+  - pattern: "**"
+    access:
+      read: ["admin@example.com"]
+`
+	err := os.WriteFile(realAclFile, []byte(aclContent), 0644)
+	require.NoError(t, err)
+	
+	// Create a directory with a symlinked ACL file
+	symlinkDir := filepath.Join(tempDir, "symlinked")
+	err = os.Mkdir(symlinkDir, 0755)
+	require.NoError(t, err)
+	
+	symlinkAclFile := filepath.Join(symlinkDir, AclFileName)
+	err = os.Symlink(realAclFile, symlinkAclFile)
+	require.NoError(t, err)
+	
+	// Test all ACL operations reject symlinks
+	
+	// 1. Exists should return false for symlinked ACL
+	assert.False(t, Exists(symlinkDir), "Exists() should reject symlinked ACL files")
+	
+	// 2. LoadFromFile should error for symlinked ACL
+	_, err = LoadFromFile(symlinkDir)
+	assert.Error(t, err, "LoadFromFile() should reject symlinked ACL files")
+	assert.Contains(t, err.Error(), "symlinks are not allowed", "Error should mention symlink restriction")
+	
+	// 3. AsACLPath and IsACLFile should work normally (they don't check file existence)
+	aclPath := AsACLPath(symlinkDir)
+	assert.Equal(t, symlinkAclFile, aclPath, "AsACLPath should work normally")
+	assert.True(t, IsACLFile(aclPath), "IsACLFile should work normally")
+	
+	// 4. Test that WithoutACLPath works normally
+	dirPath := WithoutACLPath(aclPath)
+	// Note: WithoutACLPath may add trailing separator, so we use filepath.Clean for comparison
+	assert.Equal(t, symlinkDir, filepath.Clean(dirPath), "WithoutACLPath should work normally")
+	
+	// Verify that regular files still work
+	regularDir := filepath.Join(tempDir, "regular")
+	err = os.Mkdir(regularDir, 0755)
+	require.NoError(t, err)
+	
+	regularAclFile := filepath.Join(regularDir, AclFileName)
+	err = os.WriteFile(regularAclFile, []byte(aclContent), 0644)
+	require.NoError(t, err)
+	
+	// Regular ACL files should work normally
+	assert.True(t, Exists(regularDir), "Regular ACL files should work")
+	
+	_, err = LoadFromFile(regularDir)
+	assert.NoError(t, err, "LoadFromFile should work with regular ACL files")
+}
+
+func TestConstants(t *testing.T) {
+	// Test that the constants have expected values
+	// This ensures the constants are correctly defined and haven't been accidentally changed
+	assert.Equal(t, "syft.pub.yaml", AclFileName, "ACL filename constant should be correct")
+	assert.Equal(t, "*", Everyone, "Everyone constant should be correct")
+	assert.Equal(t, "**", AllFiles, "AllFiles pattern should be correct")
+	assert.Equal(t, true, SetTerminal, "SetTerminal constant should be true")
+	assert.Equal(t, false, UnsetTerminal, "UnsetTerminal constant should be false")
+}
+
+func TestPathEdgeCases(t *testing.T) {
+	// Test edge cases in path manipulation functions
+	// This ensures robust handling of unusual but valid path scenarios
+	
+	// Test with paths containing special characters
+	specialPath := "/home/user with spaces/syft.pub.yaml"
+	assert.True(t, IsACLFile(specialPath), "Paths with spaces should be handled correctly")
+	
+	// Test with Unicode characters
+	unicodePath := "/home/用户/syft.pub.yaml"
+	assert.True(t, IsACLFile(unicodePath), "Unicode paths should be handled correctly")
+	
+	// Test with multiple slashes
+	multiSlashPath := "/home//user///syft.pub.yaml"
+	expected := "/home//user///syft.pub.yaml"
+	assert.Equal(t, expected, AsACLPath(multiSlashPath), "Multiple slashes should be preserved")
+	
+	// Test with backslashes (Windows-style paths)
+	windowsPath := "C:\\Users\\user\\syft.pub.yaml"
+	assert.True(t, IsACLFile(windowsPath), "Windows-style paths should be detected")
+}

--- a/internal/aclspec/limits_test.go
+++ b/internal/aclspec/limits_test.go
@@ -1,0 +1,123 @@
+package aclspec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultLimits(t *testing.T) {
+	// Test that DefaultLimits creates a Limits object with expected default values
+	// This is critical because these defaults affect security and functionality
+	limits := DefaultLimits()
+
+	// Verify the limits object is not nil
+	assert.NotNil(t, limits, "DefaultLimits should return a non-nil Limits object")
+
+	// Test file count limit - default should be 0 (unlimited)
+	assert.Equal(t, uint32(0), limits.MaxFiles, 
+		"Default MaxFiles should be 0 (unlimited) to not restrict file count by default")
+
+	// Test file size limit - default should be 0 (unlimited)
+	assert.Equal(t, int64(0), limits.MaxFileSize, 
+		"Default MaxFileSize should be 0 (unlimited) to not restrict file size by default")
+
+	// Test directory permission - default should allow directories
+	assert.True(t, limits.AllowDirs, 
+		"Default should allow directories since most use cases need directory creation")
+
+	// Test symlink permission - default should NOT allow symlinks for security
+	assert.False(t, limits.AllowSymlinks, 
+		"Default should not allow symlinks for security reasons (prevent symlink attacks)")
+}
+
+func TestLimitsStruct(t *testing.T) {
+	// Test creating Limits with custom values
+	// This validates the struct can hold different configurations correctly
+	customLimits := &Limits{
+		MaxFiles:      100,
+		MaxFileSize:   1024 * 1024, // 1MB
+		AllowDirs:     false,
+		AllowSymlinks: true,
+	}
+
+	assert.Equal(t, uint32(100), customLimits.MaxFiles, "Custom MaxFiles should be preserved")
+	assert.Equal(t, int64(1024*1024), customLimits.MaxFileSize, "Custom MaxFileSize should be preserved")
+	assert.False(t, customLimits.AllowDirs, "Custom AllowDirs should be preserved")
+	assert.True(t, customLimits.AllowSymlinks, "Custom AllowSymlinks should be preserved")
+}
+
+func TestLimitsZeroValues(t *testing.T) {
+	// Test that zero values in Limits struct behave as expected
+	// This is important for understanding the semantic meaning of zero values
+	var limits Limits
+
+	// Zero values should represent the most restrictive settings
+	assert.Equal(t, uint32(0), limits.MaxFiles, "Zero value MaxFiles should be 0")
+	assert.Equal(t, int64(0), limits.MaxFileSize, "Zero value MaxFileSize should be 0")
+	assert.False(t, limits.AllowDirs, "Zero value AllowDirs should be false (more restrictive)")
+	assert.False(t, limits.AllowSymlinks, "Zero value AllowSymlinks should be false (more secure)")
+}
+
+func TestLimitsIndependence(t *testing.T) {
+	// Test that multiple calls to DefaultLimits return independent objects
+	// This ensures modifications to one instance don't affect others
+	limits1 := DefaultLimits()
+	limits2 := DefaultLimits()
+
+	// Verify they start with the same values
+	assert.Equal(t, limits1.MaxFiles, limits2.MaxFiles)
+	assert.Equal(t, limits1.MaxFileSize, limits2.MaxFileSize)
+	assert.Equal(t, limits1.AllowDirs, limits2.AllowDirs)
+	assert.Equal(t, limits1.AllowSymlinks, limits2.AllowSymlinks)
+
+	// Modify one instance
+	limits1.MaxFiles = 50
+	limits1.AllowDirs = false
+
+	// Verify the other instance is unchanged
+	assert.Equal(t, uint32(0), limits2.MaxFiles, "Modifying one instance should not affect another")
+	assert.True(t, limits2.AllowDirs, "Modifying one instance should not affect another")
+}
+
+func TestLimitsExtremeValues(t *testing.T) {
+	// Test Limits with extreme values to ensure robust handling
+	// This validates the struct can handle boundary conditions
+	extremeLimits := &Limits{
+		MaxFiles:      ^uint32(0), // Maximum uint32 value
+		MaxFileSize:   9223372036854775807, // Maximum int64 value
+		AllowDirs:     true,
+		AllowSymlinks: true,
+	}
+
+	// These extreme values should be preserved without overflow or corruption
+	assert.Equal(t, ^uint32(0), extremeLimits.MaxFiles, "Maximum uint32 value should be preserved")
+	assert.Equal(t, int64(9223372036854775807), extremeLimits.MaxFileSize, "Maximum int64 value should be preserved")
+	assert.True(t, extremeLimits.AllowDirs, "Boolean values should be preserved")
+	assert.True(t, extremeLimits.AllowSymlinks, "Boolean values should be preserved")
+}
+
+func TestLimitsSemantics(t *testing.T) {
+	// Test the semantic meaning of limit values
+	// This documents and validates the intended behavior of different settings
+	
+	// Test unlimited semantics (0 values)
+	unlimited := &Limits{
+		MaxFiles:    0,
+		MaxFileSize: 0,
+	}
+	
+	// Zero should mean "no limit" for numeric fields
+	// This is a common convention in Unix systems
+	assert.Equal(t, uint32(0), unlimited.MaxFiles, "Zero MaxFiles should mean unlimited")
+	assert.Equal(t, int64(0), unlimited.MaxFileSize, "Zero MaxFileSize should mean unlimited")
+	
+	// Test specific limits
+	limited := &Limits{
+		MaxFiles:    10,
+		MaxFileSize: 1000,
+	}
+	
+	assert.True(t, limited.MaxFiles > 0, "Non-zero MaxFiles should impose a limit")
+	assert.True(t, limited.MaxFileSize > 0, "Non-zero MaxFileSize should impose a limit")
+}

--- a/internal/aclspec/rule_test.go
+++ b/internal/aclspec/rule_test.go
@@ -1,0 +1,247 @@
+package aclspec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRule(t *testing.T) {
+	// Test creating a new Rule with all components
+	// This validates the core Rule constructor works correctly
+	pattern := "*.txt"
+	access := PublicReadAccess()
+	limits := DefaultLimits()
+
+	rule := NewRule(pattern, access, limits)
+
+	// Verify all components are properly assigned
+	assert.NotNil(t, rule, "NewRule should return a non-nil Rule")
+	assert.Equal(t, pattern, rule.Pattern, "Pattern should be preserved")
+	assert.Equal(t, access, rule.Access, "Access should be preserved")
+	assert.Equal(t, limits, rule.Limits, "Limits should be preserved")
+}
+
+func TestNewRuleWithDifferentPatterns(t *testing.T) {
+	// Test creating rules with various pattern types
+	// This ensures the constructor handles different glob patterns correctly
+	testCases := []struct {
+		pattern string
+		desc    string
+	}{
+		{
+			pattern: "**",
+			desc:    "Universal pattern should be preserved",
+		},
+		{
+			pattern: "*.go",
+			desc:    "Extension-based pattern should be preserved",
+		},
+		{
+			pattern: "specific.txt",
+			desc:    "Specific filename pattern should be preserved",
+		},
+		{
+			pattern: "folder/**/*.py",
+			desc:    "Complex nested pattern should be preserved",
+		},
+		{
+			pattern: "",
+			desc:    "Empty pattern should be preserved (even if invalid)",
+		},
+	}
+
+	access := PrivateAccess()
+	limits := DefaultLimits()
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rule := NewRule(tc.pattern, access, limits)
+			assert.Equal(t, tc.pattern, rule.Pattern, tc.desc)
+		})
+	}
+}
+
+func TestNewRuleWithDifferentAccess(t *testing.T) {
+	// Test creating rules with different access configurations
+	// This validates rules can be created with various permission levels
+	pattern := "test.txt"
+	limits := DefaultLimits()
+
+	testCases := []struct {
+		access *Access
+		desc   string
+	}{
+		{
+			access: PrivateAccess(),
+			desc:   "Private access should be preserved",
+		},
+		{
+			access: PublicReadAccess(),
+			desc:   "Public read access should be preserved",
+		},
+		{
+			access: PublicReadWriteAccess(),
+			desc:   "Public read-write access should be preserved",
+		},
+		{
+			access: SharedReadAccess("user1", "user2"),
+			desc:   "Shared read access should be preserved",
+		},
+		{
+			access: SharedReadWriteAccess("maintainer"),
+			desc:   "Shared read-write access should be preserved",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rule := NewRule(pattern, tc.access, limits)
+			assert.Equal(t, tc.access, rule.Access, tc.desc)
+		})
+	}
+}
+
+func TestNewRuleWithDifferentLimits(t *testing.T) {
+	// Test creating rules with different limit configurations
+	// This validates rules can enforce various restrictions
+	pattern := "test.txt"
+	access := PrivateAccess()
+
+	testCases := []struct {
+		limits *Limits
+		desc   string
+	}{
+		{
+			limits: DefaultLimits(),
+			desc:   "Default limits should be preserved",
+		},
+		{
+			limits: &Limits{
+				MaxFileSize:   1024,
+				MaxFiles:      10,
+				AllowDirs:     false,
+				AllowSymlinks: false,
+			},
+			desc: "Custom restrictive limits should be preserved",
+		},
+		{
+			limits: &Limits{
+				MaxFileSize:   0, // Unlimited
+				MaxFiles:      0, // Unlimited
+				AllowDirs:     true,
+				AllowSymlinks: true,
+			},
+			desc: "Custom permissive limits should be preserved",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rule := NewRule(pattern, access, tc.limits)
+			assert.Equal(t, tc.limits, rule.Limits, tc.desc)
+		})
+	}
+}
+
+func TestNewRuleWithNilInputs(t *testing.T) {
+	// Test creating rules with nil inputs
+	// This documents behavior with invalid inputs (system should handle gracefully)
+	pattern := "test.txt"
+
+	// Test with nil access (this might be invalid but shouldn't crash)
+	rule := NewRule(pattern, nil, DefaultLimits())
+	assert.Equal(t, pattern, rule.Pattern, "Pattern should be preserved even with nil access")
+	assert.Nil(t, rule.Access, "Nil access should be preserved")
+	assert.NotNil(t, rule.Limits, "Limits should be preserved")
+
+	// Test with nil limits (this might be invalid but shouldn't crash)
+	rule = NewRule(pattern, PrivateAccess(), nil)
+	assert.Equal(t, pattern, rule.Pattern, "Pattern should be preserved even with nil limits")
+	assert.NotNil(t, rule.Access, "Access should be preserved")
+	assert.Nil(t, rule.Limits, "Nil limits should be preserved")
+}
+
+func TestNewDefaultRule(t *testing.T) {
+	// Test creating a default rule (catch-all pattern)
+	// This validates the convenience constructor for the most common default rule
+	access := PrivateAccess()
+	limits := DefaultLimits()
+
+	rule := NewDefaultRule(access, limits)
+
+	// Verify the rule uses the universal pattern
+	assert.NotNil(t, rule, "NewDefaultRule should return a non-nil Rule")
+	assert.Equal(t, AllFiles, rule.Pattern, "Default rule should use the AllFiles pattern (**)")
+	assert.Equal(t, access, rule.Access, "Access should be preserved")
+	assert.Equal(t, limits, rule.Limits, "Limits should be preserved")
+}
+
+func TestNewDefaultRuleWithDifferentAccess(t *testing.T) {
+	// Test default rule creation with various access levels
+	// This ensures default rules can be created with any permission configuration
+	limits := DefaultLimits()
+
+	testCases := []struct {
+		access *Access
+		desc   string
+	}{
+		{
+			access: PrivateAccess(),
+			desc:   "Default rule with private access",
+		},
+		{
+			access: PublicReadAccess(),
+			desc:   "Default rule with public read access",
+		},
+		{
+			access: SharedReadWriteAccess("admin"),
+			desc:   "Default rule with shared access",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rule := NewDefaultRule(tc.access, limits)
+			assert.Equal(t, AllFiles, rule.Pattern, "All default rules should use AllFiles pattern")
+			assert.Equal(t, tc.access, rule.Access, tc.desc)
+		})
+	}
+}
+
+func TestRulePatternConstants(t *testing.T) {
+	// Test that rules correctly use the expected pattern constants
+	// This ensures consistency in pattern usage across the system
+	
+	// Default rule should use AllFiles constant
+	defaultRule := NewDefaultRule(PrivateAccess(), DefaultLimits())
+	assert.Equal(t, "**", defaultRule.Pattern, "Default rule should use the AllFiles constant value")
+	assert.Equal(t, AllFiles, defaultRule.Pattern, "Default rule should use AllFiles constant")
+	
+	// Custom rule should preserve custom pattern
+	customRule := NewRule("custom/*.txt", PrivateAccess(), DefaultLimits())
+	assert.NotEqual(t, AllFiles, customRule.Pattern, "Custom rule should not use AllFiles pattern")
+	assert.Equal(t, "custom/*.txt", customRule.Pattern, "Custom rule should preserve its pattern")
+}
+
+func TestRuleIndependence(t *testing.T) {
+	// Test that multiple rules are independent objects
+	// This ensures modifying one rule doesn't affect others
+	access1 := PrivateAccess()
+	access2 := PublicReadAccess()
+	limits1 := DefaultLimits()
+	limits2 := &Limits{MaxFileSize: 1000}
+
+	rule1 := NewRule("*.txt", access1, limits1)
+	rule2 := NewRule("*.md", access2, limits2)
+
+	// Verify rules are independent
+	assert.NotEqual(t, rule1.Pattern, rule2.Pattern, "Rules should have different patterns")
+	assert.NotEqual(t, rule1.Access, rule2.Access, "Rules should have different access")
+	assert.NotEqual(t, rule1.Limits, rule2.Limits, "Rules should have different limits")
+
+	// Verify shared objects are actually the same references when intended
+	rule3 := NewRule("*.go", access1, limits1)
+	assert.Equal(t, rule1.Access, rule3.Access, "Rules sharing the same access object should reference the same object")
+	assert.Equal(t, rule1.Limits, rule3.Limits, "Rules sharing the same limits object should reference the same object")
+}

--- a/internal/aclspec/ruleset.go
+++ b/internal/aclspec/ruleset.go
@@ -30,8 +30,21 @@ func (r *RuleSet) AllRules() []*Rule {
 }
 
 // LoadFromFile loads a RuleSet from the specified file path
+// For security reasons, symlinks are not allowed as ACL files
 func LoadFromFile(path string) (*RuleSet, error) {
 	aclPath := AsACLPath(path)
+	
+	// Check if file is a symlink before opening
+	stat, err := os.Lstat(aclPath)
+	if err != nil {
+		return nil, err
+	}
+	
+	// Reject symlinks for security reasons
+	if stat.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("symlinks are not allowed as ACL files: %s", aclPath)
+	}
+	
 	fd, err := os.Open(aclPath)
 	if err != nil {
 		return nil, err

--- a/internal/aclspec/ruleset_test.go
+++ b/internal/aclspec/ruleset_test.go
@@ -1,0 +1,368 @@
+package aclspec
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewRuleSet(t *testing.T) {
+	// Test creating a new RuleSet with basic configuration
+	// This validates the core RuleSet constructor
+	path := "test/path"
+	terminal := true
+	rule1 := NewRule("*.txt", PublicReadAccess(), DefaultLimits())
+	rule2 := NewRule("*.md", PrivateAccess(), DefaultLimits())
+
+	ruleset := NewRuleSet(path, terminal, rule1, rule2)
+
+	// Verify all components are properly assigned
+	assert.NotNil(t, ruleset, "NewRuleSet should return a non-nil RuleSet")
+	assert.Equal(t, path, ruleset.Path, "Path should be preserved")
+	assert.Equal(t, terminal, ruleset.Terminal, "Terminal flag should be preserved")
+	assert.Len(t, ruleset.Rules, 2, "Should have exactly 2 rules")
+	assert.Contains(t, ruleset.Rules, rule1, "Should contain first rule")
+	assert.Contains(t, ruleset.Rules, rule2, "Should contain second rule")
+}
+
+func TestNewRuleSetWithAclPath(t *testing.T) {
+	// Test that NewRuleSet correctly handles ACL file paths
+	// This ensures the constructor normalizes paths by removing ACL filename
+	aclPath := "test/path/syft.pub.yaml"
+	expectedPath := "test/path/"
+
+	ruleset := NewRuleSet(aclPath, false)
+
+	assert.Equal(t, expectedPath, ruleset.Path, "ACL filename should be stripped from path")
+}
+
+func TestNewRuleSetWithNoRules(t *testing.T) {
+	// Test creating a RuleSet with no initial rules
+	// This validates the constructor works with empty rule sets
+	ruleset := NewRuleSet("test/path", false)
+
+	assert.Equal(t, "test/path", ruleset.Path)
+	assert.False(t, ruleset.Terminal)
+	assert.Empty(t, ruleset.Rules, "RuleSet with no rules should have empty Rules slice")
+}
+
+func TestAllRules(t *testing.T) {
+	// Test the AllRules method returns the correct rules
+	// This is a simple getter but important for the interface
+	rule1 := NewRule("*.txt", PublicReadAccess(), DefaultLimits())
+	rule2 := NewRule("*.md", PrivateAccess(), DefaultLimits())
+	ruleset := NewRuleSet("test", false, rule1, rule2)
+
+	rules := ruleset.AllRules()
+
+	assert.Len(t, rules, 2, "AllRules should return all rules")
+	assert.Contains(t, rules, rule1, "Should contain first rule")
+	assert.Contains(t, rules, rule2, "Should contain second rule")
+}
+
+func TestLoadFromReader(t *testing.T) {
+	// Test loading RuleSet from YAML reader
+	// This validates the core YAML parsing functionality
+	yamlContent := `
+terminal: true
+rules:
+  - pattern: "*.txt"
+    access:
+      read: ["*"]
+  - pattern: "private/*"
+    access:
+      read: ["admin"]
+      write: ["admin"]
+`
+
+	reader := io.NopCloser(strings.NewReader(yamlContent))
+	ruleset, err := LoadFromReader("test/path", reader)
+
+	require.NoError(t, err, "LoadFromReader should succeed with valid YAML")
+	assert.NotNil(t, ruleset, "Should return a non-nil RuleSet")
+
+	// Verify basic properties
+	assert.Equal(t, "test/path", ruleset.Path, "Path should be set correctly")
+	assert.True(t, ruleset.Terminal, "Terminal flag should be parsed correctly")
+
+	// Should have the 2 explicit rules plus 1 default rule added by setDefaults
+	assert.Len(t, ruleset.Rules, 3, "Should have 2 explicit rules + 1 default rule")
+
+	// Verify the first rule
+	rule1 := ruleset.Rules[0]
+	assert.Equal(t, "*.txt", rule1.Pattern, "First rule pattern should be correct")
+	assert.True(t, rule1.Access.Read.Contains("*"), "First rule should grant read access to everyone")
+
+	// Verify the second rule
+	rule2 := ruleset.Rules[1]
+	assert.Equal(t, "private/*", rule2.Pattern, "Second rule pattern should be correct")
+	assert.True(t, rule2.Access.Read.Contains("admin"), "Second rule should grant read access to admin")
+	assert.True(t, rule2.Access.Write.Contains("admin"), "Second rule should grant write access to admin")
+}
+
+func TestLoadFromReaderWithMinimalYAML(t *testing.T) {
+	// Test loading with minimal YAML (only terminal flag)
+	// This validates default rule injection works correctly
+	yamlContent := `terminal: false`
+
+	reader := io.NopCloser(strings.NewReader(yamlContent))
+	ruleset, err := LoadFromReader("test", reader)
+
+	require.NoError(t, err, "LoadFromReader should succeed with minimal YAML")
+	assert.False(t, ruleset.Terminal, "Terminal flag should be parsed correctly")
+
+	// Should have exactly 1 default rule added by setDefaults
+	assert.Len(t, ruleset.Rules, 1, "Should have 1 default rule")
+	assert.Equal(t, "**", ruleset.Rules[0].Pattern, "Default rule should have AllFiles pattern")
+}
+
+func TestLoadFromReaderWithEmptyYAML(t *testing.T) {
+	// Test loading with completely empty YAML
+	// This validates the system handles empty files gracefully
+	yamlContent := ``
+
+	reader := io.NopCloser(strings.NewReader(yamlContent))
+	ruleset, err := LoadFromReader("test", reader)
+
+	require.NoError(t, err, "LoadFromReader should succeed with empty YAML")
+	assert.False(t, ruleset.Terminal, "Terminal should default to false")
+
+	// Should have exactly 1 default rule added by setDefaults
+	assert.Len(t, ruleset.Rules, 1, "Should have 1 default rule")
+	assert.Equal(t, "**", ruleset.Rules[0].Pattern, "Default rule should have AllFiles pattern")
+}
+
+func TestLoadFromReaderWithInvalidYAML(t *testing.T) {
+	// Test that invalid YAML is properly rejected
+	// This ensures the system fails safely on malformed input
+	yamlContent := `
+invalid: yaml: content:
+  - missing
+    proper: structure
+`
+
+	reader := io.NopCloser(strings.NewReader(yamlContent))
+	ruleset, err := LoadFromReader("test", reader)
+
+	assert.Error(t, err, "LoadFromReader should fail with invalid YAML")
+	assert.Nil(t, ruleset, "Should return nil RuleSet on error")
+}
+
+func TestLoadFromFile(t *testing.T) {
+	// Test loading RuleSet from file on disk
+	// This validates file I/O integration
+	tempDir := t.TempDir()
+	aclFile := filepath.Join(tempDir, AclFileName)
+
+	yamlContent := `
+terminal: true
+rules:
+  - pattern: "*.go"
+    access:
+      read: ["developers@company.com"]
+`
+
+	err := os.WriteFile(aclFile, []byte(yamlContent), 0644)
+	require.NoError(t, err, "Should be able to write test file")
+
+	ruleset, err := LoadFromFile(tempDir)
+	require.NoError(t, err, "LoadFromFile should succeed")
+
+	assert.Equal(t, tempDir, ruleset.Path, "Path should be directory (without ACL filename)")
+	assert.True(t, ruleset.Terminal, "Terminal flag should be loaded correctly")
+	assert.Len(t, ruleset.Rules, 2, "Should have 1 explicit rule + 1 default rule")
+}
+
+func TestLoadFromFileNonExistent(t *testing.T) {
+	// Test loading from non-existent file
+	// This validates error handling for missing files
+	nonExistentPath := "/path/that/does/not/exist"
+
+	ruleset, err := LoadFromFile(nonExistentPath)
+	assert.Error(t, err, "LoadFromFile should fail for non-existent file")
+	assert.Nil(t, ruleset, "Should return nil RuleSet on error")
+}
+
+func TestRuleSetSave(t *testing.T) {
+	// Test saving RuleSet to file
+	// This validates YAML serialization and file I/O
+	tempDir := t.TempDir()
+
+	// Create a RuleSet with test data
+	rule1 := NewRule("*.txt", PublicReadAccess(), DefaultLimits())
+	rule2 := NewRule("secret/*", PrivateAccess(), &Limits{MaxFileSize: 1024})
+	ruleset := NewRuleSet(tempDir, true, rule1, rule2)
+
+	err := ruleset.Save()
+	require.NoError(t, err, "Save should succeed")
+
+	// Verify the file was created
+	aclFile := filepath.Join(tempDir, AclFileName)
+	assert.FileExists(t, aclFile, "ACL file should be created")
+
+	// Load the file back and verify content
+	content, err := os.ReadFile(aclFile)
+	require.NoError(t, err, "Should be able to read saved file")
+
+	var loaded RuleSet
+	err = yaml.Unmarshal(content, &loaded)
+	require.NoError(t, err, "Saved YAML should be valid")
+
+	assert.True(t, loaded.Terminal, "Terminal flag should be preserved")
+	assert.Len(t, loaded.Rules, 2, "All rules should be saved")
+}
+
+func TestRuleSetSaveInvalidPath(t *testing.T) {
+	// Test saving to invalid path
+	// This validates error handling for file I/O failures
+	ruleset := NewRuleSet("/invalid/path/that/cannot/be/created", false)
+
+	err := ruleset.Save()
+	assert.Error(t, err, "Save should fail for invalid path")
+}
+
+func TestSetDefaults(t *testing.T) {
+	// Test the setDefaults function directly
+	// This validates the default rule injection logic
+
+	// Test with nil rules
+	ruleset := &RuleSet{Path: "test", Terminal: false, Rules: nil}
+	result, err := setDefaults(ruleset)
+
+	require.NoError(t, err, "setDefaults should succeed with nil rules")
+	assert.Len(t, result.Rules, 1, "Should add exactly one default rule")
+	assert.Equal(t, "**", result.Rules[0].Pattern, "Default rule should have AllFiles pattern")
+}
+
+func TestSetDefaultsWithExistingDefaultRule(t *testing.T) {
+	// Test setDefaults when a default rule already exists
+	// This ensures default rules aren't duplicated
+	existingDefault := NewRule("**", PrivateAccess(), DefaultLimits())
+	customRule := NewRule("*.txt", PublicReadAccess(), DefaultLimits())
+
+	ruleset := &RuleSet{
+		Path:     "test",
+		Terminal: false,
+		Rules:    []*Rule{customRule, existingDefault},
+	}
+
+	result, err := setDefaults(ruleset)
+
+	require.NoError(t, err, "setDefaults should succeed with existing default rule")
+	assert.Len(t, result.Rules, 2, "Should not add additional default rule")
+
+	// Verify the existing default rule is preserved
+	hasDefault := false
+	for _, rule := range result.Rules {
+		if rule.Pattern == "**" {
+			hasDefault = true
+			break
+		}
+	}
+	assert.True(t, hasDefault, "Should preserve existing default rule")
+}
+
+func TestSetDefaultsValidation(t *testing.T) {
+	// Test setDefaults validation of rule requirements
+	// This ensures invalid rules are properly rejected
+
+	// Test with empty pattern
+	invalidRule := NewRule("", PrivateAccess(), DefaultLimits())
+	ruleset := &RuleSet{
+		Path:     "test",
+		Terminal: false,
+		Rules:    []*Rule{invalidRule},
+	}
+
+	result, err := setDefaults(ruleset)
+	assert.Error(t, err, "setDefaults should reject rules with empty patterns")
+	assert.Nil(t, result, "Should return nil on validation error")
+
+	// Test with nil access
+	invalidRule2 := NewRule("*.txt", nil, DefaultLimits())
+	ruleset2 := &RuleSet{
+		Path:     "test",
+		Terminal: false,
+		Rules:    []*Rule{invalidRule2},
+	}
+
+	result, err = setDefaults(ruleset2)
+	assert.Error(t, err, "setDefaults should reject rules with nil access")
+	assert.Nil(t, result, "Should return nil on validation error")
+}
+
+func TestSetDefaultsLimitsInjection(t *testing.T) {
+	// Test that setDefaults adds default limits to rules missing them
+	// This ensures all rules have proper limits configuration
+	ruleWithoutLimits := NewRule("*.txt", PrivateAccess(), nil)
+
+	ruleset := &RuleSet{
+		Path:     "test",
+		Terminal: false,
+		Rules:    []*Rule{ruleWithoutLimits},
+	}
+
+	result, err := setDefaults(ruleset)
+
+	require.NoError(t, err, "setDefaults should succeed and inject limits")
+	assert.NotNil(t, result.Rules[0].Limits, "Rule should have limits after setDefaults")
+
+	// Verify the limits are the default limits
+	expectedLimits := DefaultLimits()
+	assert.Equal(t, expectedLimits.MaxFiles, result.Rules[0].Limits.MaxFiles)
+	assert.Equal(t, expectedLimits.MaxFileSize, result.Rules[0].Limits.MaxFileSize)
+	assert.Equal(t, expectedLimits.AllowDirs, result.Rules[0].Limits.AllowDirs)
+	assert.Equal(t, expectedLimits.AllowSymlinks, result.Rules[0].Limits.AllowSymlinks)
+}
+
+func TestRuleSetRoundTrip(t *testing.T) {
+	// Test complete round-trip: create -> save -> load -> verify
+	// This validates the entire serialization/deserialization pipeline
+	tempDir := t.TempDir()
+
+	// Create original RuleSet
+	original := NewRuleSet(tempDir, true,
+		NewRule("*.go", SharedReadAccess("dev1@company.com", "dev2@university.edu"), DefaultLimits()),
+		NewRule("docs/*", PublicReadAccess(), DefaultLimits()),
+	)
+
+	// Save to file
+	err := original.Save()
+	require.NoError(t, err, "Save should succeed")
+
+	// Load from file
+	loaded, err := LoadFromFile(tempDir)
+	require.NoError(t, err, "Load should succeed")
+
+	// Verify key properties are preserved
+	assert.Equal(t, original.Path, loaded.Path, "Path should be preserved")
+	assert.Equal(t, original.Terminal, loaded.Terminal, "Terminal flag should be preserved")
+
+	// Note: loaded will have additional default rule, so we check the original rules exist
+	assert.True(t, len(loaded.Rules) >= len(original.Rules), "Loaded rules should include all original rules")
+
+	// Verify specific rules exist (order might differ due to default rule injection)
+	hasGoRule := false
+	hasDocsRule := false
+	for _, rule := range loaded.Rules {
+		if rule.Pattern == "*.go" {
+			hasGoRule = true
+			assert.True(t, rule.Access.Read.Contains("dev1@company.com"), "Go rule should preserve dev1 access")
+			assert.True(t, rule.Access.Read.Contains("dev2@university.edu"), "Go rule should preserve dev2 access")
+		}
+		if rule.Pattern == "docs/*" {
+			hasDocsRule = true
+			assert.True(t, rule.Access.Read.Contains("*"), "Docs rule should preserve public access")
+			// Note: Limits are not serialized to YAML (yaml:"-" tag), so they get default values after round-trip
+			assert.NotNil(t, rule.Limits, "Docs rule should have default limits after round-trip")
+		}
+	}
+	assert.True(t, hasGoRule, "Should preserve *.go rule")
+	assert.True(t, hasDocsRule, "Should preserve docs/* rule")
+}

--- a/internal/server/acl/level_test.go
+++ b/internal/server/acl/level_test.go
@@ -1,0 +1,211 @@
+package acl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccessLevelString(t *testing.T) {
+	// Test the String() method for all AccessLevel constants
+	// This validates that each access level has the correct string representation
+	// which is important for logging, debugging, and user-facing error messages
+	testCases := []struct {
+		level    AccessLevel
+		expected string
+		desc     string
+	}{
+		{
+			level:    AccessRead,
+			expected: "Read",
+			desc:     "AccessRead should return 'Read'",
+		},
+		{
+			level:    AccessCreate,
+			expected: "Create",
+			desc:     "AccessCreate should return 'Create'",
+		},
+		{
+			level:    AccessWrite,
+			expected: "Write",
+			desc:     "AccessWrite should return 'Write'",
+		},
+		{
+			level:    AccessAdmin,
+			expected: "Admin",
+			desc:     "AccessAdmin should return 'Admin'",
+		},
+		{
+			level:    0,
+			expected: "None",
+			desc:     "Zero value should return 'None'",
+		},
+		{
+			level:    AccessLevel(16),
+			expected: "Unknown",
+			desc:     "Undefined values should return 'Unknown'",
+		},
+		{
+			level:    AccessRead | AccessWrite,
+			expected: "Read+Write",
+			desc:     "Combined permissions should be joined with '+'",
+		},
+		{
+			level:    AccessRead | AccessCreate | AccessWrite,
+			expected: "Read+Create+Write",
+			desc:     "Multiple combined permissions should be joined in order",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			result := tc.level.String()
+			assert.Equal(t, tc.expected, result, tc.desc)
+		})
+	}
+}
+
+func TestAccessLevelStringUnknown(t *testing.T) {
+	// Test String() method with invalid/unknown access level values
+	// This ensures the system handles undefined access levels gracefully
+	unknownLevel := AccessLevel(16) // Invalid access level (higher than any defined bit)
+	result := unknownLevel.String()
+	assert.Equal(t, "Unknown", result, "Unknown access levels should return 'Unknown'")
+}
+
+func TestAccessLevelValues(t *testing.T) {
+	// Test that AccessLevel constants have the expected values
+	// Using bit flags: 1 << iota creates powers of 2
+	
+	assert.Equal(t, AccessLevel(1), AccessRead, "AccessRead should be 1 (1 << 0)")
+	assert.Equal(t, AccessLevel(2), AccessCreate, "AccessCreate should be 2 (1 << 1)")
+	assert.Equal(t, AccessLevel(4), AccessWrite, "AccessWrite should be 4 (1 << 2)")
+	assert.Equal(t, AccessLevel(8), AccessAdmin, "AccessAdmin should be 8 (1 << 3)")
+}
+
+func TestAccessLevelUniqueness(t *testing.T) {
+	// Test that all AccessLevel constants are unique
+	// This prevents accidental duplicate values that could cause permission conflicts
+	levels := []AccessLevel{
+		AccessRead,
+		AccessCreate,
+		AccessWrite,
+		AccessAdmin,
+	}
+
+	// Check that no two levels have the same value
+	for i, level1 := range levels {
+		for j, level2 := range levels {
+			if i != j {
+				assert.NotEqual(t, level1, level2, 
+					"AccessLevel constants should be unique: %s and %s have the same value", 
+					level1.String(), level2.String())
+			}
+		}
+	}
+}
+
+func TestAccessLevelHierarchy(t *testing.T) {
+	// Test the logical hierarchy of access levels
+	// This documents the intended permission hierarchy in the system
+	
+	// Verify the ordering based on bit values
+	assert.True(t, AccessRead < AccessCreate, "Read should be lower than Create")
+	assert.True(t, AccessCreate < AccessWrite, "Create should be lower than Write")
+	assert.True(t, AccessWrite < AccessAdmin, "Write should be lower than Admin")
+	assert.True(t, AccessRead < AccessAdmin, "Read should be lower than Admin")
+}
+
+func TestAccessLevelZeroValue(t *testing.T) {
+	// Test the zero value of AccessLevel
+	// This ensures the default/uninitialized value behaves correctly
+	var zeroLevel AccessLevel
+	
+	assert.Equal(t, AccessLevel(0), zeroLevel, "Zero value should be 0")
+	assert.Equal(t, "None", zeroLevel.String(), "Zero value should return 'None'")
+	
+	// Zero should not match any defined permission
+	assert.NotEqual(t, AccessRead, zeroLevel, "Zero should not equal AccessRead")
+	assert.NotEqual(t, AccessCreate, zeroLevel, "Zero should not equal AccessCreate")
+	assert.NotEqual(t, AccessWrite, zeroLevel, "Zero should not equal AccessWrite")
+	assert.NotEqual(t, AccessAdmin, zeroLevel, "Zero should not equal AccessAdmin")
+}
+
+func TestAccessLevelCasting(t *testing.T) {
+	// Test that AccessLevel can be properly cast from and to uint8
+	// This validates the underlying type compatibility
+	
+	// Test casting from uint8
+	readLevel := AccessLevel(1)
+	assert.Equal(t, AccessRead, readLevel, "Should be able to cast uint8 to AccessLevel")
+	
+	// Test casting to uint8
+	readValue := uint8(AccessRead)
+	assert.Equal(t, uint8(1), readValue, "Should be able to cast AccessLevel to uint8")
+	
+	// Test round-trip casting
+	originalLevel := AccessAdmin
+	castValue := uint8(originalLevel)
+	backToLevel := AccessLevel(castValue)
+	assert.Equal(t, originalLevel, backToLevel, "Round-trip casting should preserve value")
+}
+
+func TestAccessLevelStringConsistency(t *testing.T) {
+	// Test that String() method is consistent across multiple calls
+	// This ensures no side effects or state changes in the String() method
+	level := AccessWrite
+	
+	firstCall := level.String()
+	secondCall := level.String()
+	thirdCall := level.String()
+	
+	assert.Equal(t, firstCall, secondCall, "String() should return consistent results")
+	assert.Equal(t, secondCall, thirdCall, "String() should return consistent results")
+	assert.Equal(t, "Write", firstCall, "String() should return correct value")
+}
+
+func TestAccessLevelEdgeCases(t *testing.T) {
+	// Test edge cases and boundary values
+	// This ensures robust handling of unusual but possible values
+	
+	// Test maximum uint8 value
+	maxLevel := AccessLevel(255)
+	assert.Equal(t, "Read+Create+Write+Admin", maxLevel.String(), "Maximum value should show all known bits set")
+	
+	// Test values between defined constants
+	betweenLevels := AccessLevel(16) // Higher than all defined constants
+	assert.Equal(t, "Unknown", betweenLevels.String(), "Undefined values should be unknown")
+	
+	// Test that undefined values are handled correctly
+	undefinedLevel := AccessLevel(32)
+	assert.Equal(t, "Unknown", undefinedLevel.String(), "Higher undefined values should be unknown")
+}
+
+func TestAccessLevelBitOperations(t *testing.T) {
+	// Test bit flag operations
+	// This validates that permissions can be combined and checked using bitwise operations
+	
+	// Test combining permissions
+	readWrite := AccessRead | AccessWrite
+	assert.Equal(t, AccessLevel(5), readWrite, "Read | Write should be 5 (1 | 4)")
+	assert.Equal(t, "Read+Write", readWrite.String(), "Combined permissions should show both")
+	
+	// Test checking individual permissions
+	allPerms := AccessRead | AccessCreate | AccessWrite | AccessAdmin
+	assert.True(t, (allPerms & AccessRead) == AccessRead, "Should have Read permission")
+	assert.True(t, (allPerms & AccessCreate) == AccessCreate, "Should have Create permission")
+	assert.True(t, (allPerms & AccessWrite) == AccessWrite, "Should have Write permission")
+	assert.True(t, (allPerms & AccessAdmin) == AccessAdmin, "Should have Admin permission")
+	
+	// Test absence of permissions
+	readOnly := AccessRead
+	assert.True(t, (readOnly & AccessRead) == AccessRead, "Should have Read permission")
+	assert.False(t, (readOnly & AccessWrite) == AccessWrite, "Should not have Write permission")
+	assert.False(t, (readOnly & AccessAdmin) == AccessAdmin, "Should not have Admin permission")
+	
+	// Test removing permissions
+	allButAdmin := allPerms &^ AccessAdmin
+	assert.True(t, (allButAdmin & AccessRead) == AccessRead, "Should still have Read")
+	assert.True(t, (allButAdmin & AccessWrite) == AccessWrite, "Should still have Write")
+	assert.False(t, (allButAdmin & AccessAdmin) == AccessAdmin, "Should not have Admin")
+}


### PR DESCRIPTION
Core Changes:

Terminal node enforcement: Prevent child rulesets from being added under terminal nodes for proper security boundaries
Symlink security: Reject symlinked ACL files in Exists() and LoadFromFile() to prevent security vulnerabilities
Rule removal fix: RemoveRuleSet now only clears rules from target node while preserving child nodes, preventing accidental data loss
Rule clearing: SetRules properly clears existing rules when passed nil/empty ruleset
Technical Details:

tree.go: Add ErrTerminalNodeExists, validate terminal nodes in AddRuleSet, rewrite RemoveRuleSet to preserve children
node.go: Fix SetRules to clear rules when nil/empty input provided
aclspec.go: Replace os.Stat with os.Lstat and add symlink rejection in Exists()
ruleset.go: Add symlink validation in LoadFromFile() with descriptive error messages
Tests added to internal/server/acl and internal/aclspec packages to increase coverage and validate new security behaviors.