### PR TITLE
Update Go setup action and version in workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,9 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24.3'
           
       - name: Install just
         uses: taiki-e/install-action@just

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,9 @@ jobs:
           fetch-depth: 0  # Required for svu to work properly with git history
         
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24.3'
           
       - name: Install just
         uses: taiki-e/install-action@just


### PR DESCRIPTION
Upgrade the Go setup action to version 5 and update the Go version to 1.24.3 in the workflows.