### PR TITLE
Streamline version bump process by removing manual script

### DIFF
--- a/justfile
+++ b/justfile
@@ -261,15 +261,15 @@ bump type: version-utils
     # 1. Use `just show-version` to see current version and next versions
     # 2. Use `just bump type` to update files only (manual commit/tag)
     # 3. Use `just release type` to update files, commit, and tag automatically
-    # 4. Use `just update-version-files version=X.Y.Z` for custom versions
-    #
+    # 4. The version.go file is updated automatically with the new version 
+    #    from the git tag using the goreleaser.yaml file.
+
     # Examples:
     #   just show-version                    # Show current and next versions
     #   just bump patch                      # Update files to next patch version
     #   just bump minor                      # Update files to next minor version
     #   just bump major                      # Update files to next major version
     #   just release patch                   # Bump, commit, and tag patch version
-    #   just update-version-files version=1.2.3  # Set specific version
     
     if [ -z "{{ type }}" ]; then
         echo -e "{{ _red }}Error: bump type is required{{ _nc }}"
@@ -291,7 +291,6 @@ bump type: version-utils
     echo -e "{{ _cyan }}Bumping {{ type }} version...{{ _nc }}"
     new_version=$(svu {{ type }} | sed 's/^v//')
     echo -e "{{ _green }}New version: $new_version{{ _nc }}"
-    just update-version-files version="$new_version"
     echo -e "{{ _green }}Version bumped to $new_version{{ _nc }}"
     echo -e "{{ _yellow }}Don't forget to commit and tag:{{ _nc }}"
     echo "  git add ."
@@ -322,7 +321,6 @@ release type: version-utils
     echo -e "{{ _cyan }}Releasing {{ type }} version...{{ _nc }}"
     new_version=$(svu {{ type }} | sed 's/^v//')
     echo -e "{{ _green }}New version: $new_version{{ _nc }}"
-    just update-version-files version="$new_version"
     just commit-and-tag version="$new_version"
     echo -e "{{ _green }}✓ Released {{ type }} version $new_version{{ _nc }}"
 
@@ -387,29 +385,6 @@ commit-and-tag version:
     fi
     
     echo -e "{{ _green }}Version $version_value has been committed and tagged!{{ _nc }}"
-
-[group('version')]
-update-version-files version:
-    #!/bin/bash
-    set -eou pipefail
-    
-    # Extract version from parameter (handle both "version=0.5.1" and "0.5.1" formats)
-    version_value="{{ version }}"
-    if [[ "$version_value" == version=* ]]; then
-        version_value="${version_value#version=}"
-    fi
-    
-    if [ -z "$version_value" ]; then
-        echo -e "{{ _red }}Error: version parameter is required{{ _nc }}"
-        echo "Usage: just update-version-files version=1.2.3"
-        exit 1
-    fi
-    
-    echo -e "{{ _cyan }}Updating version to $version_value in all files...{{ _nc }}"
-    
-    # Update version.go
-    sed -i "s/Version = \".*\"/Version = \"$version_value-dev\"/" internal/version/version.go
-    echo -e "{{ _green }}✓ Updated internal/version/version.go{{ _nc }}"
 
 [group('version')]
 version-utils:


### PR DESCRIPTION
Eliminate the manual version update script to automate the version update process using the goreleaser.yaml file. This change simplifies version management and enhances efficiency.