### PR TITLE
HTTP/RPC Fixes

### DIFF
--- a/internal/client/sync/sync_engine_priority_http_download.go
+++ b/internal/client/sync/sync_engine_priority_http_download.go
@@ -1,0 +1,60 @@
+package sync
+
+import (
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/openmined/syftbox/internal/syftmsg"
+)
+
+func (se *SyncEngine) processHttpMessage(msg *syftmsg.Message) {
+	httpMsg, ok := msg.Data.(*syftmsg.HttpMsg)
+	if !ok {
+		slog.Error("sync", "type", SyncPriority, "op", OpWriteLocal, "msgType", msg.Type, "msgId", msg.Id, "error", "invalid message data", "data", msg.Data)
+		return
+	}
+
+	// rpc message file name
+	fileName := httpMsg.Id + ".request"
+	relPath := filepath.Join(httpMsg.SyftURL.ToLocalPath(), fileName)
+	syncRelPath := SyncPath(relPath)
+
+	se.syncStatus.SetSyncing(syncRelPath)
+	slog.Info("sync", "type", SyncPriority, "op", OpWriteLocal, "msgType", msg.Type, "msgId", msg.Id, "path", httpMsg.SyftURL.ToLocalPath(), "size", len(httpMsg.Body), "etag", httpMsg.Etag)
+
+	// rpc message file path
+	rpcLocalAbsPath := se.workspace.DatasiteAbsPath(relPath)
+
+	// a priority file was just downloaded, we don't wanna fire an event for THIS write
+	se.watcher.IgnoreOnce(rpcLocalAbsPath)
+
+	// write the RPCMsg to the file
+	err := writeFileWithIntegrityCheck(
+		rpcLocalAbsPath,
+		httpMsg.Body,
+		httpMsg.Etag,
+	)
+
+	if err != nil {
+		se.syncStatus.SetError(syncRelPath, err)
+		slog.Error("sync", "type", SyncPriority, "op", OpWriteLocal, "msgType", msg.Type, "msgId", msg.Id, "path", httpMsg.SyftURL.ToLocalPath(), "etag", httpMsg.Etag, "error", err)
+		return
+	}
+
+	fileSize := int64(len(httpMsg.Body))
+
+	// update the journal
+	se.journal.Set(&FileMetadata{
+		Path:         syncRelPath,
+		ETag:         httpMsg.Etag,
+		Size:         fileSize,
+		LastModified: time.Now(),
+		Version:      "",
+	})
+
+	se.syncStatus.SetCompleted(syncRelPath)
+
+	slog.Info("sync", "type", SyncPriority, "op", OpWriteLocal, "msgType", msg.Type, "msgId", msg.Id, "path", httpMsg.SyftURL.ToLocalPath(), "size", fileSize, "etag", httpMsg.Etag)
+
+}

--- a/internal/server/handlers/send/send_handler_types.go
+++ b/internal/server/handlers/send/send_handler_types.go
@@ -95,7 +95,7 @@ type PollResult struct {
 
 // Message store interface for storing and retrieving messages
 type RPCMsgStore interface {
-	StoreMsg(ctx context.Context, path string, msg syftmsg.SyftRPCMessage) error
+	StoreMsg(ctx context.Context, path string, msgBytes []byte) error
 	GetMsg(ctx context.Context, path string) (io.ReadCloser, error)
 	DeleteMsg(ctx context.Context, path string) error
 }

--- a/internal/server/handlers/send/send_service.go
+++ b/internal/server/handlers/send/send_service.go
@@ -2,6 +2,7 @@ package send
 
 import (
 	"context"
+	"crypto/md5"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -53,70 +54,75 @@ func NewSendService(dispatch MessageDispatcher, store RPCMsgStore, cfg *Config) 
 // SendMessage handles sending a message to a user
 func (s *SendService) SendMessage(ctx context.Context, req *MessageRequest, bodyBytes []byte) (*SendResult, error) {
 
-	// Create the HTTP message
+	// create an RPC message
+	rpcMsg, err := syftmsg.NewSyftRPCMessage(
+		req.From,
+		req.SyftURL,
+		syftmsg.SyftMethod(req.Method),
+		bodyBytes,
+		req.Headers,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create RPC message: %w", err)
+	}
+
+	rpcMsgBytes, err := rpcMsg.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal RPC message: %w", err)
+	}
+
+	etag := fmt.Sprintf("%x", md5.Sum(rpcMsgBytes))
 
 	msg := syftmsg.NewHttpMsg(
 		req.From,
 		req.SyftURL,
 		req.Method,
-		bodyBytes,
+		rpcMsgBytes,
 		req.Headers,
-		syftmsg.HttpMsgTypeRequest,
+		rpcMsg.ID.String(),
+		etag,
 	)
-
-	httpMsg := msg.Data.(*syftmsg.HttpMsg)
 
 	// TODO: Check if user has permission to send message to this application
 
 	// Dispatch the message to the user via websocket
-	if ok := s.dispatcher.Dispatch(req.SyftURL.Datasite, msg); !ok {
-		// If the message is not sent via websocket, handle it as an offline message
-		return s.handleOfflineMessage(ctx, req, httpMsg)
+	dispatched := s.dispatcher.Dispatch(req.SyftURL.Datasite, msg)
+
+	// relative rpc request file path to datasite
+	relPath := path.Join(
+		req.SyftURL.ToLocalPath(),
+		fmt.Sprintf("%s.%s", rpcMsg.ID.String(), "request"),
+	)
+
+	// Store the request in blob storage
+	err = s.store.StoreMsg(ctx, relPath, rpcMsgBytes)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to store RPC request: %w", err)
+	}
+
+	// If the message is not dispatched via websocket, return the poll url
+	if !dispatched {
+		return &SendResult{
+			Status:    http.StatusAccepted,
+			RequestID: rpcMsg.ID.String(),
+			PollURL:   s.constructPollURL(rpcMsg.ID.String(), req.SyftURL, req.From, req.AsRaw),
+		}, nil
 	}
 
 	// If the message is sent via websocket, handle the response
-	return s.handleOnlineMessage(ctx, req, httpMsg)
+	return s.checkForResponse(ctx, req, rpcMsg)
 }
 
-// handleOfflineMessage handles sending a message when the user is offline
-func (s *SendService) handleOfflineMessage(
+// checkForResponse handles sending a message when the user is online
+func (s *SendService) checkForResponse(
 	ctx context.Context,
 	req *MessageRequest,
-	httpMsg *syftmsg.HttpMsg,
+	rpcMsg *syftmsg.SyftRPCMessage,
 ) (*SendResult, error) {
-	blobPath := path.Join(
-		req.SyftURL.ToLocalPath(),
-		fmt.Sprintf("%s.%s", httpMsg.Id, httpMsg.Type),
-	)
-
-	// Create the RPC message
-	rpcMsg, err := syftmsg.NewSyftRPCMessage(*httpMsg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create RPCMsg: %w", err)
-	}
-
-	// Save the RPC message to blob storage
-	if err := s.store.StoreMsg(ctx, blobPath, *rpcMsg); err != nil {
-		return nil, fmt.Errorf("failed to save message to blob storage: %w", err)
-	}
-
-	slog.Info("saved message to blob storage", "blobPath", blobPath)
-	return &SendResult{
-		Status:    http.StatusAccepted,
-		RequestID: httpMsg.Id,
-		PollURL:   s.constructPollURL(httpMsg.Id, req.SyftURL, req.From, req.AsRaw),
-	}, nil
-}
-
-// handleOnlineMessage handles sending a message when the user is online
-func (s *SendService) handleOnlineMessage(
-	ctx context.Context,
-	req *MessageRequest,
-	httpMsg *syftmsg.HttpMsg,
-) (*SendResult, error) {
-	blobPath := path.Join(
-		req.SyftURL.ToLocalPath(),
-		fmt.Sprintf("%s.response", httpMsg.Id),
+	responseRelPath := path.Join(
+		rpcMsg.URL.ToLocalPath(),
+		fmt.Sprintf("%s.response", rpcMsg.ID.String()),
 	)
 
 	var timeout time.Duration
@@ -126,13 +132,13 @@ func (s *SendService) handleOnlineMessage(
 		timeout = s.cfg.DefaultTimeout
 	}
 
-	object, err := s.pollForObject(ctx, blobPath, timeout)
+	object, err := s.pollForObject(ctx, responseRelPath, timeout)
 	if err != nil {
 		if errors.Is(err, ErrPollTimeout) {
 			return &SendResult{
 				Status:    http.StatusAccepted,
-				RequestID: httpMsg.Id,
-				PollURL:   s.constructPollURL(httpMsg.Id, req.SyftURL, req.From, req.AsRaw),
+				RequestID: rpcMsg.ID.String(),
+				PollURL:   s.constructPollURL(rpcMsg.ID.String(), req.SyftURL, req.From, req.AsRaw),
 			}, nil
 		}
 		return nil, err
@@ -154,12 +160,12 @@ func (s *SendService) handleOnlineMessage(
 		req.SyftURL.Datasite,
 		req.SyftURL.AppName,
 		req.SyftURL.Endpoint,
-		httpMsg.Id,
+		rpcMsg.ID.String(),
 	)
 
 	return &SendResult{
 		Status:    http.StatusOK,
-		RequestID: httpMsg.Id,
+		RequestID: rpcMsg.ID.String(),
 		Response:  responseBody,
 	}, nil
 }
@@ -220,26 +226,26 @@ func (s *SendService) PollForResponse(ctx context.Context, req *PollObjectReques
 	}, nil
 }
 
-// pollForObject polls for an object in blob storage
+// pollForObject polls for an object in blob storage until the timeout is reached
+// if the object is found, it returns the object
 func (s *SendService) pollForObject(ctx context.Context, blobPath string, timeout time.Duration) (io.ReadCloser, error) {
+
+	// start the timer
 	startTime := time.Now()
 
 	for {
-		if time.Since(startTime) > timeout {
-			return nil, ErrPollTimeout
-		}
-
 		object, err := s.store.GetMsg(ctx, blobPath)
-		if err != nil {
-			// if message not found, return immediately - no need to retry
-			if errors.Is(err, ErrMsgNotFound) {
-				return nil, ErrMsgNotFound
-			}
-			// For other errors, return immediately as they are likely permanent
+		if err == nil && object != nil {
+			return object, nil
+		}
+		// If the error is not "not found", log and return immediately (permanent error)
+		if err != nil && !errors.Is(err, ErrMsgNotFound) {
 			slog.Error("poll for object failed", "error", err, "blobPath", blobPath)
 			return nil, err
-		} else if object != nil {
-			return object, nil
+		}
+
+		if time.Since(startTime) > timeout {
+			return nil, ErrPollTimeout
 		}
 
 		// Always sleep between polling attempts
@@ -292,6 +298,7 @@ func unmarshalResponse(bodyBytes []byte, asRaw bool) (map[string]interface{}, er
 
 	// Otherwise, unmarshal it as a SyftRPCMessage
 	var rpcMsg syftmsg.SyftRPCMessage
+
 	err := json.Unmarshal(bodyBytes, &rpcMsg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)

--- a/internal/server/handlers/send/send_service.go
+++ b/internal/server/handlers/send/send_service.go
@@ -176,10 +176,9 @@ func (s *SendService) PollForResponse(ctx context.Context, req *PollObjectReques
 	// Validate if the corresponding request exists
 	requestBlobPath := path.Join(req.SyftURL.ToLocalPath(), fmt.Sprintf("%s.request", req.RequestID))
 
-	_, err := s.pollForObject(ctx, requestBlobPath, s.cfg.RequestCheckTimeout)
-
+	_, err := s.store.GetMsg(ctx, requestBlobPath)
 	if err != nil {
-		if errors.Is(err, ErrPollTimeout) {
+		if errors.Is(err, ErrMsgNotFound) {
 			return nil, ErrRequestNotFound
 		}
 		return nil, err

--- a/internal/syftmsg/http_msg.go
+++ b/internal/syftmsg/http_msg.go
@@ -1,7 +1,6 @@
 package syftmsg
 
 import (
-	"github.com/google/uuid"
 	"github.com/openmined/syftbox/internal/utils"
 )
 
@@ -18,8 +17,8 @@ type HttpMsg struct {
 	Method  string            `json:"method"`
 	Headers map[string]string `json:"headers,omitempty"`
 	Body    []byte            `json:"body,omitempty"`
-	Id      string            `json:"id,omitempty"`
-	Type    HttpMsgType       `json:"type,omitempty"`
+	Id      string            `json:"id"`
+	Etag    string            `json:"etag,omitempty"`
 }
 
 func NewHttpMsg(
@@ -28,7 +27,8 @@ func NewHttpMsg(
 	method string,
 	body []byte,
 	headers map[string]string,
-	msgType HttpMsgType,
+	id string,
+	etag string,
 ) *Message {
 	return &Message{
 		Id:   generateID(),
@@ -39,8 +39,8 @@ func NewHttpMsg(
 			Method:  method,
 			Body:    body,
 			Headers: headers,
-			Id:      uuid.New().String(),
-			Type:    msgType,
+			Id:      id,
+			Etag:    etag,
 		},
 	}
 }

--- a/internal/utils/url.go
+++ b/internal/utils/url.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -118,6 +119,23 @@ func (s *SyftBoxURL) UnmarshalParam(param string) error {
 	parsed, err := FromSyftURL(param)
 	if err != nil {
 		slog.Error("Failed to parse syft url", "error", err, "url", param)
+		return err
+	}
+	*s = *parsed
+	return nil
+}
+
+func (s *SyftBoxURL) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+func (s *SyftBoxURL) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	parsed, err := FromSyftURL(str)
+	if err != nil {
 		return err
 	}
 	*s = *parsed


### PR DESCRIPTION
This pull request introduces significant changes to streamline the handling of HTTP messages and RPC messages across the codebase. The key updates include refactoring message storage and retrieval, improving logging, and enhancing the handling of online and offline message dispatch. Additionally, the `HttpMsg` structure has been updated to include an `etag` field for integrity checks.

### Refactoring and Enhancements to Message Handling:

- **Refactored `processHttpMessage` Implementation**:
  - Removed the old implementation from `sync_engine.go` and added a new implementation in `sync_engine_priority_http_download.go`. The new version includes integrity checks using `etag` and updates the journal with metadata after processing messages. [[1]](diffhunk://#diff-5dd6e4b8d09419996e946eb341da26303a57c450d99309c1fb87848b502b0baaL629-L687) [[2]](diffhunk://#diff-618ccbb0808e5c3f3edf6280fd09957617cb2f07aa7f7bc3907baf99af8c313eR1-R60)
  
- **Updated `HttpMsg` Structure**:
  - Added an `etag` field to `HttpMsg` for integrity checks and removed the `type` field. The `HttpMsg` creation now requires an `id` and `etag` explicitly. [[1]](diffhunk://#diff-011cf8bf54be853d90a47404090c8f93da32e55ce1675fc84b200aa7d90da266L21-R21) [[2]](diffhunk://#diff-011cf8bf54be853d90a47404090c8f93da32e55ce1675fc84b200aa7d90da266L31-R31) [[3]](diffhunk://#diff-011cf8bf54be853d90a47404090c8f93da32e55ce1675fc84b200aa7d90da266L42-R43)

### Improvements to Server-Side Message Storage and Retrieval:

- **Refactored `StoreMsg` Method**:
  - Changed `StoreMsg` to accept raw message bytes instead of `SyftRPCMessage` objects. This simplifies the storage process and allows for better handling of message integrity using `etag`. [[1]](diffhunk://#diff-ee27af4e8c3f7a90860b151fbfd27215f85db7ac28a4f7333c7a1b8ddd39f379L44-R62) [[2]](diffhunk://#diff-3e94d9bba201a490b9944e49c0ef6edf7cad610aa6d7889ca7d24070a10ef42aL98-R98)
  
- **Enhanced Polling Logic**:
  - Improved the `pollForObject` method to handle timeout and permanent errors more effectively. It now retries only for "not found" errors while logging and returning other errors immediately.

### Updates to Message Dispatch and Response Handling:

- **Refactored `SendMessage` Logic**:
  - Simplified the creation and dispatch of messages by introducing explicit handling of RPC messages. Offline and online message handling now use consistent paths and storage mechanisms. [[1]](diffhunk://#diff-2656502b91abdddb8823185e64919eb803663ffdbed3eb318a4220ec2fc0c5c1L56-R125) [[2]](diffhunk://#diff-2656502b91abdddb8823185e64919eb803663ffdbed3eb318a4220ec2fc0c5c1L129-R141) [[3]](diffhunk://#diff-2656502b91abdddb8823185e64919eb803663ffdbed3eb318a4220ec2fc0c5c1L173-R181)

### Test Updates:

- **Adjusted MockRPCMsgStore**:
  - Updated tests to reflect the changes in `StoreMsg` method, ensuring that raw message bytes are used instead of `SyftRPCMessage`. [[1]](diffhunk://#diff-ccbf0439540d80ef14291256711f2c1e38d17a8b95168bb3bba237dc2d556894L37-R37) [[2]](diffhunk://#diff-ccbf0439540d80ef14291256711f2c1e38d17a8b95168bb3bba237dc2d556894L105-R125)
  
- **Improved PollForResponse Tests**:
  - Enhanced test cases to verify the updated polling logic and error handling for missing requests and timeouts. [[1]](diffhunk://#diff-ccbf0439540d80ef14291256711f2c1e38d17a8b95168bb3bba237dc2d556894L362-R357) [[2]](diffhunk://#diff-ccbf0439540d80ef14291256711f2c1e38d17a8b95168bb3bba237dc2d556894L417-R412)