### PR TITLE
cleanup debug logs

### DIFF
--- a/internal/client/sync/sync_engine.go
+++ b/internal/client/sync/sync_engine.go
@@ -515,13 +515,11 @@ func (se *SyncEngine) hasModified(f1, f2 *FileMetadata) bool {
 
 	// Option 3: Fallback to Size (more reliable than ModTime)
 	if f1.Size != f2.Size {
-		slog.Debug("hasModified", "f1.Size", f1.Size, "f2.Size", f2.Size)
 		return true
 	}
 
 	// Option 4: Fallback to ModTime (use cautiously, with tolerance?)
 	if f1.LastModified != f2.LastModified {
-		slog.Debug("hasModified", "f1.LastModified", f1.LastModified, "f2.LastModified", f2.LastModified)
 		return true
 	}
 

--- a/internal/client/sync/sync_engine_priority_http_download.go
+++ b/internal/client/sync/sync_engine_priority_http_download.go
@@ -55,6 +55,4 @@ func (se *SyncEngine) processHttpMessage(msg *syftmsg.Message) {
 
 	se.syncStatus.SetCompleted(syncRelPath)
 
-	slog.Info("sync", "type", SyncPriority, "op", OpWriteLocal, "msgType", msg.Type, "msgId", msg.Id, "path", httpMsg.SyftURL.ToLocalPath(), "size", fileSize, "etag", httpMsg.Etag)
-
 }

--- a/internal/server/handlers/send/msg_store.go
+++ b/internal/server/handlers/send/msg_store.go
@@ -46,8 +46,6 @@ func (m *BlobMsgStore) StoreMsg(ctx context.Context, path string, msgBytes []byt
 	etag := fmt.Sprintf("%x", md5.Sum(msgBytes))
 	fileSize := int64(len(msgBytes))
 
-	slog.Info("Storing message", "path", path, "etag", etag, "fileSize", fileSize)
-
 	_, err := m.blob.Backend().PutObject(ctx, &blob.PutObjectParams{
 		Key:  path,
 		ETag: etag,
@@ -56,6 +54,7 @@ func (m *BlobMsgStore) StoreMsg(ctx context.Context, path string, msgBytes []byt
 	})
 
 	if err != nil {
+		slog.Error("rpc msg store", "type", "blob", "etag", etag, "fileSize", fileSize, "path", path, "error", err)
 		return fmt.Errorf("failed to store message: %w", err)
 	}
 


### PR DESCRIPTION
This pull request primarily focuses on improving logging practices by removing redundant debug and informational logs and adding error logs for better diagnostics. The changes streamline the codebase and ensure more meaningful logging.

### Logging improvements:

* [`internal/client/sync/sync_engine.go`](diffhunk://#diff-5dd6e4b8d09419996e946eb341da26303a57c450d99309c1fb87848b502b0baaL518-L524): Removed debug logs from the `hasModified` function to reduce unnecessary verbosity.
* [`internal/client/sync/sync_engine_priority_http_download.go`](diffhunk://#diff-618ccbb0808e5c3f3edf6280fd09957617cb2f07aa7f7bc3907baf99af8c313eL58-L59): Removed an informational log in the `processHttpMessage` function to simplify logging during HTTP message processing.
* [`internal/server/handlers/send/msg_store.go`](diffhunk://#diff-ee27af4e8c3f7a90860b151fbfd27215f85db7ac28a4f7333c7a1b8ddd39f379L49-L50): Removed an informational log in the `StoreMsg` function to avoid redundant logging during message storage.
* [`internal/server/handlers/send/msg_store.go`](diffhunk://#diff-ee27af4e8c3f7a90860b151fbfd27215f85db7ac28a4f7333c7a1b8ddd39f379R57): Added an error log in the `StoreMsg` function to capture detailed diagnostic information in case of failures during message storage.